### PR TITLE
[DO NOT MERGE] adds salmon background color option for US, DE flex banners

### DIFF
--- a/demo/salmon.html
+++ b/demo/salmon.html
@@ -1,0 +1,30 @@
+<!-- This file demos the hot, new salmon-colored flex banner -->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Messages Dev Sandbox (Salmon)</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+        <script src="http://localhost.paypal.com:8080/sdk.js?client-id=DEV00000000NI&components=messages"></script>
+    </head>
+    <body>
+        <div
+            class="messages"
+            data-pp-message
+            data-pp-style-layout="flex"
+            data-pp-style-logo-type="none"
+            data-pp-style-color="salmon"
+        ></div>
+        <script>
+            // paypal
+            //     .Messages({
+            //         style: {
+            //             layout: 'flex',
+            //             ratio: '8x1',
+            //             color: 'blue'
+            //         }
+            //     })
+            //     .render('.messages');
+        </script>
+    </body>
+</html>

--- a/src/locale/DE/validOptions.js
+++ b/src/locale/DE/validOptions.js
@@ -12,7 +12,7 @@ export default {
         }
     },
     flex: {
-        color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey']],
+        color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey', 'salmon']],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
     }
 };

--- a/src/locale/US/validOptions.js
+++ b/src/locale/US/validOptions.js
@@ -13,7 +13,7 @@ export default {
         }
     },
     flex: {
-        color: [Types.STRING, ['blue', 'black', 'white', 'white-no-border', 'gray|grey']],
+        color: [Types.STRING, ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'salmon']],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
     },
     legacy: {

--- a/src/messages/models/Template/styles/flex/css/color--salmon.css
+++ b/src/messages/models/Template/styles/flex/css/color--salmon.css
@@ -1,0 +1,7 @@
+.message__content {
+    color: white;
+}
+
+.message__background {
+    background: salmon;
+}

--- a/src/messages/models/Template/styles/flex/index.js
+++ b/src/messages/models/Template/styles/flex/index.js
@@ -12,6 +12,7 @@ import colorBlueRatio1x4 from './css/color--blue&&ratio--1x4.css';
 import colorBlack from './css/color--black.css';
 import colorWhite from './css/color--white.css';
 import colorWhiteNoBorder from './css/color--white-no-border.css';
+import colorSalmon from './css/color--salmon.css';
 
 export default [
     ['default', [fonts, common, base].join('\n')],
@@ -26,6 +27,7 @@ export default [
     ['color:black', colorBlack],
     ['color:white', colorWhite],
     ['color:white-no-border', colorWhiteNoBorder],
+    ['color:salmon', colorSalmon],
 
     ['color:blue && ratio:1x4', colorBlueRatio1x4]
 ];


### PR DESCRIPTION
**DO NOT MERGE, EXERCISE ONLY**

**What**:

Adding salmon-colored background to the flex banners. Can test the integration by heading to http://localhost.paypal.com:8080/salmon.html.

**Why**:

Coding exercise and getting familiar with things.

**Screenshot**:

<img width="1680" alt="Screen Shot 2020-01-15 at 9 19 55 AM" src="https://user-images.githubusercontent.com/5874373/72441197-3d2a3180-3778-11ea-8ab9-14408d7a5d19.png">