### PR TITLE
feat: Added 'salmon' color option to flex banners.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,19 +6,18 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
         <script src="//localhost.paypal.com:8080/sdk.js?client-id=DEV00000000NI&components=messages"></script>
     </head>
-
     <body>
         <div class="messages" data-pp-message></div>
         <script>
-            paypal
-                .Messages({
-                    style: {
-                        layout: 'flex',
-                        ratio: '8x1',
-                        color: 'salmon'
-                    }
-                })
-                .render('.messages');
+            // paypal
+            //     .Messages({
+            //         style: {
+            //             layout: 'flex',
+            //             ratio: '8x1',
+            //             color: 'blue'
+            //         }
+            //     })
+            //     .render('.messages');
         </script>
     </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,18 +6,19 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
         <script src="//localhost.paypal.com:8080/sdk.js?client-id=DEV00000000NI&components=messages"></script>
     </head>
+
     <body>
         <div class="messages" data-pp-message></div>
         <script>
-            // paypal
-            //     .Messages({
-            //         style: {
-            //             layout: 'flex',
-            //             ratio: '8x1',
-            //             color: 'blue'
-            //         }
-            //     })
-            //     .render('.messages');
+            paypal
+                .Messages({
+                    style: {
+                        layout: 'flex',
+                        ratio: '8x1',
+                        color: 'salmon'
+                    }
+                })
+                .render('.messages');
         </script>
     </body>
 </html>

--- a/src/locale/US/validOptions.js
+++ b/src/locale/US/validOptions.js
@@ -15,7 +15,7 @@ export default {
     flex: {
         color: [
             Types.STRING,
-            ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
+            ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale', 'salmon']
         ],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
     },

--- a/src/messages/models/Template/styles/flex/color--salmon.css
+++ b/src/messages/models/Template/styles/flex/color--salmon.css
@@ -1,0 +1,7 @@
+.message__content {
+    color: #ffffff;
+}
+
+.message__background {
+    background: salmon;
+}

--- a/src/messages/models/Template/styles/flex/index.js
+++ b/src/messages/models/Template/styles/flex/index.js
@@ -10,6 +10,7 @@ import colorGray from './color--gray.css';
 import colorBlueRatio1x4 from './color--blue&&ratio--1x4.css';
 import colorBlack from './color--black.css';
 import colorWhite from './color--white.css';
+import colorSalmon from './color--salmon.css';
 import colorWhiteNoBorder from './color--white-no-border.css';
 
 export default [
@@ -24,6 +25,7 @@ export default [
     ['color:gray', colorGray],
     ['color:black', colorBlack],
     ['color:white', colorWhite],
+    ['color:salmon', colorSalmon],
     ['color:white-no-border', colorWhiteNoBorder],
 
     ['color:blue && ratio:1x4', colorBlueRatio1x4]


### PR DESCRIPTION
# Description

Allows `salmon` to be used as a valid color when rendering a message banner with the `flex` layout. Includes updates to valid options for US locale and accompanying stylesheet.

Screenshot:
<img width="806" alt="dev-integration" src="https://user-images.githubusercontent.com/68250152/87464783-b4366a80-c5e1-11ea-9214-851db41b37c9.png">
