### PR TITLE
fix: preselecting tabs based on offer type of banner

### DIFF
--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -58,11 +58,6 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
                 sendToChild: true,
                 required: false
             },
-            messageOfferType: {
-                type: 'string',
-                queryParam: true,
-                required: true
-            },
             country: {
                 type: 'string',
                 queryParam: true,
@@ -85,11 +80,6 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
             },
 
             // Callbacks
-            track: {
-                type: 'function',
-                queryParam: false,
-                required: false
-            },
             onClick: {
                 type: 'function',
                 queryParam: false,
@@ -105,11 +95,15 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
                 queryParam: false,
                 required: false
             },
-
+            onReady: {
+                type: 'function',
+                queryParam: false,
+                required: false
+            },
             // Computed Props
             offer: {
                 type: 'string',
-                value: ({ props }) => determineInitialTab(props.messageOfferType),
+                value: ({ props }) => determineInitialTab(props.offer),
                 required: false
             },
             payerId: {

--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -17,7 +17,21 @@ const getGlobalComponent = (namespace, fn) => {
 
 // Determine pre-selected tab based on the offer type of the banner.
 // Currently only applicable to the US
-const determineInitialTab = (type = 'NI') => (startsWith(type, 'EZP') || startsWith(type, 'PALA') ? 'EZP' : 'NI');
+const determineInitialTab = (type = 'NI') => {
+    switch (true) {
+        case [
+            'EZP:ANY:EQZ',
+            'EZP:ANY:GTZ',
+            'PALA:MULTI:EQZ',
+            'PALA:MULTI:GTZ',
+            'PALA:SINGLE:EQZ',
+            'PALA:SINGLE:GTZ'
+        ].includes(type):
+            return 'EZP';
+        default:
+            return 'NI';
+    }
+};
 
 export default getGlobalComponent('__paypal_credit_modal__', () =>
     create({

--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -26,7 +26,7 @@ const determineInitialTab = (type = 'NI') => {
             'PALA:MULTI:GTZ',
             'PALA:SINGLE:EQZ',
             'PALA:SINGLE:GTZ'
-        ].includes(type):
+        ].includes(type.toUpperCase()):
             return 'EZP';
         default:
             return 'NI';

--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -15,7 +15,7 @@ const getGlobalComponent = (namespace, fn) => {
     return window[namespace];
 };
 
-// Utilize a combination of offer type and country code to determine pre-selected tab.
+// Determine pre-selected tab based on the offer type of the banner.
 // Currently only applicable to the US
 const determineInitialTab = (type = 'NI') => (startsWith(type, 'EZP') || startsWith(type, 'PALA') ? 'EZP' : 'NI');
 
@@ -44,7 +44,7 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
                 sendToChild: true,
                 required: false
             },
-            type: {
+            messageOfferType: {
                 type: 'string',
                 queryParam: true,
                 required: true
@@ -90,7 +90,7 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
             // Computed Props
             offer: {
                 type: 'string',
-                value: ({ props }) => determineInitialTab(props.type),
+                value: ({ props }) => determineInitialTab(props.messageOfferType),
                 required: false
             },
             payerId: {

--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -71,6 +71,11 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
             },
 
             // Callbacks
+            track: {
+                type: 'function',
+                queryParam: false,
+                required: false
+            },
             onClick: {
                 type: 'function',
                 queryParam: false,

--- a/src/messages/components/Modal/component.js
+++ b/src/messages/components/Modal/component.js
@@ -15,6 +15,10 @@ const getGlobalComponent = (namespace, fn) => {
     return window[namespace];
 };
 
+// Utilize a combination of offer type and country code to determine pre-selected tab.
+// Currently only applicable to the US
+const determineInitialTab = (type = 'NI') => (startsWith(type, 'EZP') || startsWith(type, 'PALA') ? 'EZP' : 'NI');
+
 export default getGlobalComponent('__paypal_credit_modal__', () =>
     create({
         tag: 'paypal-credit-modal',
@@ -84,6 +88,11 @@ export default getGlobalComponent('__paypal_credit_modal__', () =>
             },
 
             // Computed Props
+            offer: {
+                type: 'string',
+                value: ({ props }) => determineInitialTab(props.type),
+                required: false
+            },
             payerId: {
                 type: 'string',
                 queryParam: 'payer_id',

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -10,8 +10,8 @@ const renderModal = memoizeOnProps(
         const [hijackViewport, replaceViewport] = useViewportHijack();
 
         const { render, hide, updateProps } = Modal({
+            track,
             messageOfferType,
-
             // Even though these props are not included in memoize,
             // we want to pass the initial values in so we can preload one set of terms
             account: options.account,
@@ -83,8 +83,6 @@ export default {
 
             events.on('click', () => {
                 renderProm.then(() => {
-                    track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: meta.offerType });
-
                     show({
                         account: options.account,
                         merchantId: options.merchantId,

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -6,15 +6,13 @@ import Modal from './component';
 import useViewportHijack from './viewportHijack';
 
 const renderModal = memoizeOnProps(
-    ({ options, meta, track, wrapper, messageOfferType }) => {
+    ({ options, meta, track, wrapper }) => {
         const [hijackViewport, replaceViewport] = useViewportHijack();
 
         const createOnReadyHandler = () => ({ modalType }) =>
             track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
 
         const { render, hide, updateProps } = Modal({
-            track,
-            messageOfferType,
             // Even though these props are not included in memoize,
             // we want to pass the initial values in so we can preload one set of terms
             account: options.account,
@@ -81,8 +79,7 @@ export default {
                 options,
                 meta,
                 track,
-                wrapper,
-                messageOfferType: meta.offerType
+                wrapper
             });
 
             events.on('click', () => {

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -13,6 +13,7 @@ const renderModal = memoizeOnProps(
             track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
 
         const { render, hide, updateProps } = Modal({
+            offer: meta.offerType,
             // Even though these props are not included in memoize,
             // we want to pass the initial values in so we can preload one set of terms
             account: options.account,

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -5,24 +5,12 @@ import { memoizeOnProps } from '../../../utils';
 import Modal from './component';
 import useViewportHijack from './viewportHijack';
 
-function getModalType(offerCountry, offerType) {
-    switch (offerCountry) {
-        case 'DE':
-            return 'INST';
-        case 'GB':
-            return 'PL';
-        case 'US':
-        default:
-            return startsWith(offerType, 'NI') ? 'NI' : 'EZP';
-    }
-}
-
 const renderModal = memoizeOnProps(
-    ({ options, meta, track, wrapper, type }) => {
+    ({ options, meta, track, wrapper, messageOfferType }) => {
         const [hijackViewport, replaceViewport] = useViewportHijack();
 
         const { render, hide, updateProps } = Modal({
-            type,
+            messageOfferType,
 
             // Even though these props are not included in memoize,
             // we want to pass the initial values in so we can preload one set of terms
@@ -83,14 +71,19 @@ export default {
                 }
             });
         } else {
-            const modalType = getModalType(meta.offerCountry, meta.offerType);
             // The type passed in here is the offer type from the messages call.
             // The modal type is returned from a separate call and passed in as a prop
-            const { renderProm, show } = renderModal({ options, meta, track, wrapper, type: meta.offerType });
+            const { renderProm, show } = renderModal({
+                options,
+                meta,
+                track,
+                wrapper,
+                messageOfferType: meta.offerType
+            });
 
             events.on('click', () => {
                 renderProm.then(() => {
-                    track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
+                    track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: meta.offerType });
 
                     show({
                         account: options.account,

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -9,9 +9,6 @@ const renderModal = memoizeOnProps(
     ({ options, meta, track, wrapper }) => {
         const [hijackViewport, replaceViewport] = useViewportHijack();
 
-        const createOnReadyHandler = () => ({ modalType }) =>
-            track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
-
         const { render, hide, updateProps } = Modal({
             offer: meta.offerType,
             // Even though these props are not included in memoize,
@@ -34,7 +31,7 @@ const renderModal = memoizeOnProps(
                 wrapper.firstChild.focus();
                 track({ et: 'CLICK', event_type: 'modal-close', link: linkName });
             },
-            onReady: createOnReadyHandler()
+            onReady: ({ modalType }) => track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType })
         });
 
         const show = props => {

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -84,7 +84,9 @@ export default {
             });
         } else {
             const modalType = getModalType(meta.offerCountry, meta.offerType);
-            const { renderProm, show } = renderModal({ options, meta, track, wrapper, type: modalType });
+            // The type passed in here is the offer type from the messages call.
+            // The modal type is returned from a separate call and passed in as a prop
+            const { renderProm, show } = renderModal({ options, meta, track, wrapper, type: meta.offerType });
 
             events.on('click', () => {
                 renderProm.then(() => {

--- a/src/messages/components/Modal/index.js
+++ b/src/messages/components/Modal/index.js
@@ -9,6 +9,9 @@ const renderModal = memoizeOnProps(
     ({ options, meta, track, wrapper, messageOfferType }) => {
         const [hijackViewport, replaceViewport] = useViewportHijack();
 
+        const createOnReadyHandler = () => ({ modalType }) =>
+            track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
+
         const { render, hide, updateProps } = Modal({
             track,
             messageOfferType,
@@ -31,7 +34,8 @@ const renderModal = memoizeOnProps(
                 replaceViewport();
                 wrapper.firstChild.focus();
                 track({ et: 'CLICK', event_type: 'modal-close', link: linkName });
-            }
+            },
+            onReady: createOnReadyHandler()
         });
 
         const show = props => {

--- a/src/modal/Modal.jsx
+++ b/src/modal/Modal.jsx
@@ -16,7 +16,7 @@ const Modal = ({ serverData }) => (
                 {common}
             </style>
             <Container>
-                <Content />
+                <Content modalType={serverData.type} country={serverData.country} />
             </Container>
         </TransitionState>
     </ServerContext.Provider>

--- a/src/modal/Modal.jsx
+++ b/src/modal/Modal.jsx
@@ -16,7 +16,7 @@ const Modal = ({ serverData }) => (
                 {common}
             </style>
             <Container>
-                <Content modalType={serverData.type} country={serverData.country} />
+                <Content modalType={serverData.type} />
             </Container>
         </TransitionState>
     </ServerContext.Provider>

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -12,7 +12,10 @@ import Tabs from '../parts/Tabs';
 // Props type, country sent from serverData.
 const Content = ({ modalType }) => {
     // Type of the banner displayed to user.
-    const { offer } = useXProps();
+    const { track, offer } = useXProps();
+
+    // Calling track here in order to use correct modal type from server.
+    track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
 
     switch (modalType) {
         case 'NI':

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -9,7 +9,7 @@ import INST from './DE/INST';
 import PL from './GB/PL';
 import Tabs from '../parts/Tabs';
 
-// Props type, country sent from serverData.
+// modalType sent from server.
 const Content = ({ modalType }) => {
     // Type of the banner displayed to user.
     const { track } = useXProps();

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -12,7 +12,7 @@ import Tabs from '../parts/Tabs';
 // Props type, country sent from serverData.
 const Content = ({ modalType }) => {
     // Type of the banner displayed to user.
-    const { track, offer } = useXProps();
+    const { track } = useXProps();
 
     // Calling track here in order to use correct modal type from server.
     track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
@@ -34,7 +34,6 @@ const Content = ({ modalType }) => {
                         {USEzp}
                     </style>
                     <Tabs
-                        initialTabKey={offer}
                         tabs={[
                             {
                                 tabKey: 'EZP',

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -11,50 +11,29 @@ import Tabs from '../parts/Tabs';
 
 // Utilize a combination of offer type and country code to determine pre-selected tab.
 const determineInitialTab = (type = 'NI', country = 'US') => {
-    return {
-        US: (() => {
-            switch (type) {
-                case 'NI':
-                case 'NIQ':
-                case 'NI:NON-US':
-                    return 'US:NI';
-                case 'EZP:ANY:EQZ':
-                case 'EZP:ANY:GTZ':
-                case 'PALA:MULTI:EQZ':
-                case 'PALA:MULTI:GTZ':
-                case 'PALA:SINGLE:EQZ':
-                case 'PALA:SINGLE:GTZ':
-                    return 'US:EZP';
-                default:
-                    return 'US:NI';
-            }
-        })(),
-        DE: (() => {
-            switch (type) {
-                case 'INST:ANY:EQZ':
-                case 'INST:ANY:GTZ':
-                    return 'DE:INST';
-                case 'PALAQ:ANY:EQZ':
-                case 'PALAQ:ANY:GTZ':
-                    return 'DE:PALAQ';
-                default:
-                    return 'DE:INST';
-            }
-        })(),
-        GB: (() => {
-            switch (type) {
-                case 'PL':
-                case 'PLQ':
-                    return 'GB:PLQ';
-                default:
-                    return 'GB:PLQ';
-            }
-        })()
-    }[country];
+    switch (country) {
+        case 'US':
+            return [
+                'EZP:ANY:EQZ',
+                'EZP:ANY:GTZ',
+                'PALA:MULTI:EQZ',
+                'PALA:MULTI:GTZ',
+                'PALA:SINGLE:EQZ',
+                'PALA:SINGLE:GTZ'
+            ].includes(type)
+                ? 'EZP'
+                : 'NI';
+        case 'DE':
+            return 'INST';
+        case 'GB':
+            return 'PL';
+        default:
+            return 'NI';
+    }
 };
 
 // Props type, country sent from serverData.
-const Content = ({ modalType = 'NI', country = 'US' }) => {
+const Content = ({ modalType, country }) => {
     // Type of the banner displayed to user.
     const { type } = useXProps();
 
@@ -78,13 +57,13 @@ const Content = ({ modalType = 'NI', country = 'US' }) => {
                         initialTabKey={determineInitialTab(type, country)}
                         tabs={[
                             {
-                                tabKey: 'US:EZP',
+                                tabKey: 'EZP',
                                 title: 'Easy Payments',
                                 header: <EZP.Header />,
                                 body: <EZP.Content />
                             },
                             {
-                                tabKey: 'US:NI',
+                                tabKey: 'NI',
                                 title: '6 Months Special Financing',
                                 header: <NI.Header />,
                                 body: <NI.Content />

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -1,5 +1,6 @@
 /** @jsx h */
 import { h, Fragment } from 'preact';
+import { useEffect } from 'preact/hooks';
 
 import { useXProps } from '../lib/hooks';
 import { commonUS, USEzp, DEInst, GBPl } from '../styles';
@@ -12,10 +13,14 @@ import Tabs from '../parts/Tabs';
 // modalType sent from server.
 const Content = ({ modalType }) => {
     // Type of the banner displayed to user.
-    const { track } = useXProps();
+    const { onReady } = useXProps();
 
     // Calling track here in order to use correct modal type from server.
-    track({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: modalType });
+    useEffect(() => {
+        if (typeof onReady === 'function') {
+            onReady({ modalType });
+        }
+    }, [modalType]);
 
     switch (modalType) {
         case 'NI':

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -9,33 +9,10 @@ import INST from './DE/INST';
 import PL from './GB/PL';
 import Tabs from '../parts/Tabs';
 
-// Utilize a combination of offer type and country code to determine pre-selected tab.
-const determineInitialTab = (type = 'NI', country = 'US') => {
-    switch (country) {
-        case 'US':
-            return [
-                'EZP:ANY:EQZ',
-                'EZP:ANY:GTZ',
-                'PALA:MULTI:EQZ',
-                'PALA:MULTI:GTZ',
-                'PALA:SINGLE:EQZ',
-                'PALA:SINGLE:GTZ'
-            ].includes(type)
-                ? 'EZP'
-                : 'NI';
-        case 'DE':
-            return 'INST';
-        case 'GB':
-            return 'PL';
-        default:
-            return 'NI';
-    }
-};
-
 // Props type, country sent from serverData.
-const Content = ({ modalType, country }) => {
+const Content = ({ modalType }) => {
     // Type of the banner displayed to user.
-    const { type } = useXProps();
+    const { offer } = useXProps();
 
     switch (modalType) {
         case 'NI':
@@ -54,7 +31,7 @@ const Content = ({ modalType, country }) => {
                         {USEzp}
                     </style>
                     <Tabs
-                        initialTabKey={determineInitialTab(type, country)}
+                        initialTabKey={offer}
                         tabs={[
                             {
                                 tabKey: 'EZP',

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -1,6 +1,7 @@
 /** @jsx h */
 import { h, Fragment } from 'preact';
 
+import { useXProps } from '../lib/hooks';
 import { commonUS, USEzp, DEInst, GBPl } from '../styles';
 import * as NI from './US/NI';
 import * as EZP from './US/EZP';
@@ -52,8 +53,11 @@ const determineInitialTab = (type = 'NI', country = 'US') => {
     }[country];
 };
 
-// type, country sent from serverData.
+// Props type, country sent from serverData.
 const Content = ({ modalType = 'NI', country = 'US' }) => {
+    // Type of the banner displayed to user.
+    const { type } = useXProps();
+
     switch (modalType) {
         case 'NI':
             return (
@@ -71,8 +75,7 @@ const Content = ({ modalType = 'NI', country = 'US' }) => {
                         {USEzp}
                     </style>
                     <Tabs
-                        // TODO :: Pass in offer type from messages call
-                        initialTabKey={determineInitialTab(modalType, country)}
+                        initialTabKey={determineInitialTab(type, country)}
                         tabs={[
                             {
                                 tabKey: 'US:EZP',

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -12,7 +12,6 @@ import Tabs from '../parts/Tabs';
 
 // modalType sent from server.
 const Content = ({ modalType }) => {
-    // Type of the banner displayed to user.
     const { onReady } = useXProps();
 
     // Calling track here in order to use correct modal type from server.

--- a/src/modal/content/Content.jsx
+++ b/src/modal/content/Content.jsx
@@ -1,7 +1,6 @@
 /** @jsx h */
 import { h, Fragment } from 'preact';
 
-import { useXProps } from '../lib/hooks';
 import { commonUS, USEzp, DEInst, GBPl } from '../styles';
 import * as NI from './US/NI';
 import * as EZP from './US/EZP';
@@ -9,10 +8,53 @@ import INST from './DE/INST';
 import PL from './GB/PL';
 import Tabs from '../parts/Tabs';
 
-const Content = () => {
-    const { type } = useXProps();
+// Utilize a combination of offer type and country code to determine pre-selected tab.
+const determineInitialTab = (type = 'NI', country = 'US') => {
+    return {
+        US: (() => {
+            switch (type) {
+                case 'NI':
+                case 'NIQ':
+                case 'NI:NON-US':
+                    return 'US:NI';
+                case 'EZP:ANY:EQZ':
+                case 'EZP:ANY:GTZ':
+                case 'PALA:MULTI:EQZ':
+                case 'PALA:MULTI:GTZ':
+                case 'PALA:SINGLE:EQZ':
+                case 'PALA:SINGLE:GTZ':
+                    return 'US:EZP';
+                default:
+                    return 'US:NI';
+            }
+        })(),
+        DE: (() => {
+            switch (type) {
+                case 'INST:ANY:EQZ':
+                case 'INST:ANY:GTZ':
+                    return 'DE:INST';
+                case 'PALAQ:ANY:EQZ':
+                case 'PALAQ:ANY:GTZ':
+                    return 'DE:PALAQ';
+                default:
+                    return 'DE:INST';
+            }
+        })(),
+        GB: (() => {
+            switch (type) {
+                case 'PL':
+                case 'PLQ':
+                    return 'GB:PLQ';
+                default:
+                    return 'GB:PLQ';
+            }
+        })()
+    }[country];
+};
 
-    switch (type) {
+// type, country sent from serverData.
+const Content = ({ modalType = 'NI', country = 'US' }) => {
+    switch (modalType) {
         case 'NI':
             return (
                 <Fragment>
@@ -29,13 +71,17 @@ const Content = () => {
                         {USEzp}
                     </style>
                     <Tabs
+                        // TODO :: Pass in offer type from messages call
+                        initialTabKey={determineInitialTab(modalType, country)}
                         tabs={[
                             {
+                                tabKey: 'US:EZP',
                                 title: 'Easy Payments',
                                 header: <EZP.Header />,
                                 body: <EZP.Content />
                             },
                             {
+                                tabKey: 'US:NI',
                                 title: '6 Months Special Financing',
                                 header: <NI.Header />,
                                 body: <NI.Content />

--- a/src/modal/parts/Tabs.jsx
+++ b/src/modal/parts/Tabs.jsx
@@ -4,14 +4,25 @@ import { useState, useEffect } from 'preact/hooks';
 
 import { useTransitionState, useXProps } from '../lib/hooks';
 
-const Tabs = ({ tabs }) => {
-    const [currentTab, selectTab] = useState(0);
+const getInitialTabIndex = (initialTabKey, tabs) => {
+    let selected = 0;
+    tabs.forEach(({ tabKey }, index) => {
+        if (tabKey === initialTabKey) {
+            selected = index;
+        }
+    });
+    return selected;
+};
+
+const Tabs = ({ tabs, initialTabKey }) => {
+    // TODO :: Initialize current tab based on 'pre-selected' criteria
+    const [currentTab, selectTab] = useState(getInitialTabIndex(initialTabKey, tabs));
     const [transitionState] = useTransitionState();
     const { onClick } = useXProps();
 
     useEffect(() => {
         if (transitionState === 'CLOSED') {
-            selectTab(0);
+            selectTab(getInitialTabIndex(initialTabKey, tabs));
         }
     }, [transitionState]);
 

--- a/src/modal/parts/Tabs.jsx
+++ b/src/modal/parts/Tabs.jsx
@@ -11,18 +11,20 @@ const getInitialTabIndex = (initialTabKey, tabs) => {
             selected = index;
         }
     });
+
     return selected;
 };
 
 const Tabs = ({ tabs, initialTabKey }) => {
-    // TODO :: Initialize current tab based on 'pre-selected' criteria
-    const [currentTab, selectTab] = useState(getInitialTabIndex(initialTabKey, tabs));
+    const initialTab = getInitialTabIndex(initialTabKey, tabs);
+
+    const [currentTab, selectTab] = useState(initialTab);
     const [transitionState] = useTransitionState();
     const { onClick } = useXProps();
 
     useEffect(() => {
         if (transitionState === 'CLOSED') {
-            selectTab(getInitialTabIndex(initialTabKey, tabs));
+            selectTab(initialTab);
         }
     }, [transitionState]);
 

--- a/src/modal/parts/Tabs.jsx
+++ b/src/modal/parts/Tabs.jsx
@@ -6,12 +6,12 @@ import { useTransitionState, useXProps } from '../lib/hooks';
 
 const getInitialTabIndex = (initialTabKey, tabs) => tabs.findIndex(({ tabKey }) => tabKey === initialTabKey) || 0;
 
-const Tabs = ({ tabs, initialTabKey }) => {
-    const initialTab = getInitialTabIndex(initialTabKey, tabs);
+const Tabs = ({ tabs }) => {
+    const { offer, onClick } = useXProps();
+    const initialTab = getInitialTabIndex(offer, tabs);
+    const [transitionState] = useTransitionState();
 
     const [currentTab, selectTab] = useState(initialTab);
-    const [transitionState] = useTransitionState();
-    const { onClick } = useXProps();
 
     useEffect(() => {
         if (transitionState === 'CLOSED') {

--- a/src/modal/parts/Tabs.jsx
+++ b/src/modal/parts/Tabs.jsx
@@ -4,16 +4,7 @@ import { useState, useEffect } from 'preact/hooks';
 
 import { useTransitionState, useXProps } from '../lib/hooks';
 
-const getInitialTabIndex = (initialTabKey, tabs) => {
-    let selected = 0;
-    tabs.forEach(({ tabKey }, index) => {
-        if (tabKey === initialTabKey) {
-            selected = index;
-        }
-    });
-
-    return selected;
-};
+const getInitialTabIndex = (initialTabKey, tabs) => tabs.findIndex(({ tabKey }) => tabKey === initialTabKey) || 0;
 
 const Tabs = ({ tabs, initialTabKey }) => {
     const initialTab = getInitialTabIndex(initialTabKey, tabs);

--- a/src/modal/parts/Tabs.jsx
+++ b/src/modal/parts/Tabs.jsx
@@ -7,6 +7,7 @@ import { useTransitionState, useXProps } from '../lib/hooks';
 const getInitialTabIndex = (initialTabKey, tabs) => tabs.findIndex(({ tabKey }) => tabKey === initialTabKey) || 0;
 
 const Tabs = ({ tabs }) => {
+    // offer type of banner used to determine which tab to pre-select
     const { offer, onClick } = useXProps();
     const initialTab = getInitialTabIndex(offer, tabs);
     const [transitionState] = useTransitionState();

--- a/src/utils/fonts.js
+++ b/src/utils/fonts.js
@@ -5,7 +5,7 @@ import { prependStyle } from './elements';
 
 const loadedFonts = new Map();
 
-export default function(doc) {
+export default doc => {
     if (!loadedFonts.has(doc)) {
         loadedFonts.set(
             doc,
@@ -53,4 +53,4 @@ export default function(doc) {
     }
 
     return loadedFonts.get(doc);
-}
+};

--- a/tests/unit/spec/src/messages/components/Modal/index.test.js
+++ b/tests/unit/spec/src/messages/components/Modal/index.test.js
@@ -26,6 +26,7 @@ describe('Modal Component', () => {
     const defaultXProps = {
         offer: 'NI',
         show: jest.fn(),
+        track: jest.fn(),
         onProps: jest.fn()
     };
 
@@ -38,6 +39,14 @@ describe('Modal Component', () => {
         useXProps.mockClear();
         // Need to destroy the 'preact tree' in order to clear component state.
         render(null, document.body);
+    });
+
+    it('Should call track with the appropriate modal type', () => {
+        setupModal(defaultProps);
+        expect(defaultXProps.track).toBeCalledWith({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: 'NI' });
+
+        setupModal({ ...defaultProps, type: 'EZP' });
+        expect(defaultXProps.track).toBeCalledWith({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: 'EZP' });
     });
 
     it('Should render NI modal', () => {

--- a/tests/unit/spec/src/messages/components/Modal/index.test.js
+++ b/tests/unit/spec/src/messages/components/Modal/index.test.js
@@ -3,6 +3,13 @@ import { render } from 'preact';
 import { setupModal } from 'src/modal';
 import { useXProps } from 'src/modal/lib/hooks/helpers';
 
+// Mock only useEffect
+// Mocking as useLayoutEffect here in order to fire synchronously for tests.
+jest.mock('preact/hooks', () => ({
+    ...jest.requireActual('preact/hooks'),
+    useEffect: jest.requireActual('preact/hooks').useLayoutEffect
+}));
+
 jest.mock('src/modal/lib/hooks/helpers');
 
 describe('Modal Component', () => {
@@ -26,8 +33,8 @@ describe('Modal Component', () => {
     const defaultXProps = {
         offer: 'NI',
         show: jest.fn(),
-        track: jest.fn(),
-        onProps: jest.fn()
+        onProps: jest.fn(),
+        onReady: jest.fn()
     };
 
     beforeEach(() => {
@@ -41,12 +48,16 @@ describe('Modal Component', () => {
         render(null, document.body);
     });
 
-    it('Should call track with the appropriate modal type', () => {
+    it('Should call onReady with the appropriate modal type', () => {
         setupModal(defaultProps);
-        expect(defaultXProps.track).toBeCalledWith({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: 'NI' });
+        expect(defaultXProps.onReady).toBeCalledWith({
+            modalType: 'NI'
+        });
 
         setupModal({ ...defaultProps, type: 'EZP' });
-        expect(defaultXProps.track).toBeCalledWith({ et: 'CLIENT_IMPRESSION', event_type: 'modal-open', modal: 'EZP' });
+        expect(defaultXProps.onReady).toBeCalledWith({
+            modalType: 'EZP'
+        });
     });
 
     it('Should render NI modal', () => {

--- a/tests/unit/spec/src/messages/components/Modal/index.test.js
+++ b/tests/unit/spec/src/messages/components/Modal/index.test.js
@@ -24,8 +24,7 @@ describe('Modal Component', () => {
     };
 
     const defaultXProps = {
-        type: 'NI',
-        country: 'US',
+        offer: 'NI',
         show: jest.fn(),
         onProps: jest.fn()
     };
@@ -50,7 +49,7 @@ describe('Modal Component', () => {
     });
 
     it('Should render EZP modal, selecting EZP tab', () => {
-        useXProps.mockReturnValue({ ...defaultXProps, type: 'PALA:MULTI:GTZ' });
+        useXProps.mockReturnValue({ ...defaultXProps, offer: 'EZP' });
 
         setupModal({ ...defaultProps, type: 'EZP' });
 

--- a/tests/unit/spec/src/messages/components/Modal/index.test.js
+++ b/tests/unit/spec/src/messages/components/Modal/index.test.js
@@ -1,3 +1,71 @@
+import { render } from 'preact';
+
+import { setupModal } from 'src/modal';
+import { useXProps } from 'src/modal/lib/hooks/helpers';
+
+jest.mock('src/modal/lib/hooks/helpers');
+
 describe('Modal Component', () => {
     it.todo('Creates the appropriate wrapper');
+    const defaultProps = {
+        type: 'NI',
+        country: 'US',
+        terms: {
+            type: 'pala',
+            minAmount: 0,
+            amount: '999.99',
+            formattedAmount: '999.99',
+            offers: [],
+            formattedMinAmount: '0'
+        },
+        payerId: 'ABCDE12345',
+        meta: {},
+        aprEntry: { formattedDate: '3/1/2020', apr: 25.49 }
+    };
+
+    const defaultXProps = {
+        type: 'NI',
+        country: 'US',
+        show: jest.fn(),
+        onProps: jest.fn()
+    };
+
+    beforeEach(() => {
+        useXProps.mockReturnValue(defaultXProps);
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        useXProps.mockClear();
+        // Need to destroy the 'preact tree' in order to clear component state.
+        render(null, document.body);
+    });
+
+    it('Should render NI modal', () => {
+        setupModal(defaultProps);
+
+        expect(document.children[0]).toContainHTML(
+            'No Interest if paid in full in 6 months on purchases of $99 or more'
+        );
+    });
+
+    it('Should render EZP modal, selecting EZP tab', () => {
+        useXProps.mockReturnValue({ ...defaultXProps, type: 'PALA:MULTI:GTZ' });
+
+        setupModal({ ...defaultProps, type: 'EZP' });
+
+        expect(document.children[0]).toContainHTML('Easy Payments');
+
+        expect(document.querySelector('.tabs').children.length).toBeGreaterThan(1);
+        // EZP Tab
+        expect(document.querySelector('.tabs').children[0]).toHaveClass('tab--selected');
+    });
+
+    it('Should render EZP modal, selecting NI tab', () => {
+        setupModal({ ...defaultProps, type: 'EZP' });
+
+        expect(document.querySelector('.tabs').children.length).toBeGreaterThan(1);
+        // NI Tab
+        expect(document.querySelector('.tabs').children[1]).toHaveClass('tab--selected');
+    });
 });

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -33,6 +33,8 @@ module.exports = app => {
     app.get('/credit-presentment/smart/modal', (req, res) => {
         const { country, amount } = req.query;
         const props = {
+            type: 'NI',
+            country: 'US',
             aprEntry: { formattedDate: '3/1/2020', apr: 25.49 },
             terms: getTerms(country, Number(amount)),
             meta: {

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -40,7 +40,7 @@ module.exports = app => {
     app.get('/credit-presentment/smart/modal', (req, res) => {
         const { country, amount, client_id: clientId, payer_id: payerId = 'DEV00000000NI' } = req.query;
 
-        const offer = devAccountMap[clientId || payerId] ? devAccountMap[clientId || payerId][1] : 'NI';
+        const offer = devAccountMap[clientId || payerId] ? devAccountMap[clientId || payerId][1] : 'ni';
 
         const props = {
             type: mockModalType(country, offer),

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -25,12 +25,12 @@ const devAccountMap = {
     DEV00000GBPLQ: ['GB', 'plq']
 };
 
-const mockModalType = ([country, offer]) =>
+const mockModalType = account =>
     ({
         GB: 'PL',
         DE: 'INST',
-        US: ['ni', 'niq', 'ni_non-us', 'niq_non-us'].includes(offer) ? 'NI' : 'EZP'
-    }[country]);
+        US: ['ni', 'niq', 'ni_non-us', 'niq_non-us'].includes(account[1]) ? 'NI' : 'EZP'
+    }[account[0]]);
 
 module.exports = app => {
     app.get('/ppcredit/messagingLogger', (req, res) => {

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -40,7 +40,7 @@ module.exports = app => {
     app.get('/credit-presentment/smart/modal', (req, res) => {
         const { country, amount, client_id: clientId, payer_id: payerId = 'DEV00000000NI' } = req.query;
 
-        const offer = devAccountMap[clientId || payerId][1];
+        const offer = devAccountMap[clientId || payerId] ? devAccountMap[clientId || payerId][1] : 'NI';
 
         const props = {
             type: mockModalType(country, offer),

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -25,12 +25,12 @@ const devAccountMap = {
     DEV00000GBPLQ: ['GB', 'plq']
 };
 
-const mockModalType = account =>
+const mockModalType = (country, offer) =>
     ({
         GB: 'PL',
         DE: 'INST',
-        US: ['ni', 'niq', 'ni_non-us', 'niq_non-us'].includes(account[1]) ? 'NI' : 'EZP'
-    }[account[0]]);
+        US: ['ni', 'niq', 'ni_non-us', 'niq_non-us'].includes(offer) ? 'NI' : 'EZP'
+    }[country] || 'NI');
 
 module.exports = app => {
     app.get('/ppcredit/messagingLogger', (req, res) => {
@@ -38,9 +38,12 @@ module.exports = app => {
     });
 
     app.get('/credit-presentment/smart/modal', (req, res) => {
-        const { country, amount, client_id: clientId } = req.query;
+        const { country, amount, client_id: clientId, payer_id: payerId = 'DEV00000000NI' } = req.query;
+
+        const offer = devAccountMap[clientId || payerId][1];
+
         const props = {
-            type: mockModalType(devAccountMap[clientId]),
+            type: mockModalType(country, offer),
             country,
             aprEntry: { formattedDate: '3/1/2020', apr: 25.49 },
             terms: getTerms(country, Number(amount)),

--- a/utils/devServerProxy.js
+++ b/utils/devServerProxy.js
@@ -25,16 +25,23 @@ const devAccountMap = {
     DEV00000GBPLQ: ['GB', 'plq']
 };
 
+const mockModalType = ([country, offer]) =>
+    ({
+        GB: 'PL',
+        DE: 'INST',
+        US: ['ni', 'niq', 'ni_non-us', 'niq_non-us'].includes(offer) ? 'NI' : 'EZP'
+    }[country]);
+
 module.exports = app => {
     app.get('/ppcredit/messagingLogger', (req, res) => {
         res.send('');
     });
 
     app.get('/credit-presentment/smart/modal', (req, res) => {
-        const { country, amount } = req.query;
+        const { country, amount, client_id: clientId } = req.query;
         const props = {
-            type: 'NI',
-            country: 'US',
+            type: mockModalType(devAccountMap[clientId]),
+            country,
             aprEntry: { formattedDate: '3/1/2020', apr: 25.49 },
             terms: getTerms(country, Number(amount)),
             meta: {


### PR DESCRIPTION
Allows appropriate tab to be pre-selected based on the offer type of the banner presented to the user.