### PR TITLE
fix: modal slow scroll behavior on mobile

### DIFF
--- a/src/modal/content/US/EZP.jsx
+++ b/src/modal/content/US/EZP.jsx
@@ -23,12 +23,13 @@ export const Header = () => {
     const buttonRef = useRef();
     const handleApplyNowClick = useApplyNow('Apply Now');
 
-    useScroll(event => {
+    useScroll(({ target: { scrollTop } }) => {
         const { offsetTop, clientHeight } = buttonRef.current;
 
         // Ensure first that the button is being displayed
-        if (offsetTop) {
-            if (event.target.scrollTop - offsetTop < clientHeight + 30) {
+        // See NI.jsx for comment on why value of scrollTop is checked here.
+        if (scrollTop && offsetTop) {
+            if (scrollTop - offsetTop < clientHeight + 30) {
                 window.dispatchEvent(createEvent('apply-now-hidden'));
             } else {
                 window.dispatchEvent(createEvent('apply-now-visible'));

--- a/src/modal/content/US/NI.jsx
+++ b/src/modal/content/US/NI.jsx
@@ -30,12 +30,14 @@ export const Header = () => {
     const buttonRef = useRef();
     const handleApplyNowClick = useApplyNow('Apply Now');
 
-    useScroll(event => {
+    useScroll(({ target: { scrollTop } }) => {
         const { offsetTop, clientHeight } = buttonRef.current;
 
         // Ensure first that the button is being displayed
-        if (offsetTop) {
-            if (event.target.scrollTop - offsetTop < clientHeight + 30) {
+        // event.target.scrollTop alternates between 0 and some positive number as the user scrolls
+        // Checking the value here prevents erratic behavior wrt the logo and apply now button
+        if (scrollTop && offsetTop) {
+            if (scrollTop - offsetTop < clientHeight + 30) {
                 window.dispatchEvent(createEvent('apply-now-hidden'));
             } else {
                 window.dispatchEvent(createEvent('apply-now-visible'));

--- a/src/modal/content/US/NI.jsx
+++ b/src/modal/content/US/NI.jsx
@@ -33,8 +33,10 @@ export const Header = () => {
     useScroll(({ target: { scrollTop } }) => {
         const { offsetTop, clientHeight } = buttonRef.current;
 
+        console.info(scrollTop);
+
         // Ensure first that the button is being displayed
-        // event.target.scrollTop alternates between 0 and some positive number as the user scrolls
+        // event.target.scrollTop resets itself to 0 under certain circumstances as the user scrolls on mobile
         // Checking the value here prevents erratic behavior wrt the logo and apply now button
         if (scrollTop && offsetTop) {
             if (scrollTop - offsetTop < clientHeight + 30) {

--- a/src/modal/content/US/NI.jsx
+++ b/src/modal/content/US/NI.jsx
@@ -33,8 +33,6 @@ export const Header = () => {
     useScroll(({ target: { scrollTop } }) => {
         const { offsetTop, clientHeight } = buttonRef.current;
 
-        console.info(scrollTop);
-
         // Ensure first that the button is being displayed
         // event.target.scrollTop resets itself to 0 under certain circumstances as the user scrolls on mobile
         // Checking the value here prevents erratic behavior wrt the logo and apply now button


### PR DESCRIPTION
Slow scrolling on mobile no longer results in erratic transition of logo:

![slow-scroll-opt](https://user-images.githubusercontent.com/68250152/89183357-16d9b100-d565-11ea-9b7e-6e7e540a4d57.gif)
