### PR TITLE
fix: update GB qualifying attribute check

### DIFF
--- a/src/components/modal/content/GB/parts/PL.jsx
+++ b/src/components/modal/content/GB/parts/PL.jsx
@@ -10,7 +10,7 @@ const headline = () => {
 
     const { qualifying } = useProductMeta('GPL');
 
-    if (qualifying.toLowerCase() !== 'true') {
+    if (qualifying?.toLowerCase() !== 'true') {
         return (
             <h1 className="offer">
                 {unqualified[0]} <br /> {unqualified[1]}
@@ -34,7 +34,7 @@ const PL = () => {
             <div className="left">
                 {headline()}
                 <p className="subheadline">
-                    {qualifying.toLowerCase() === 'true' ? subHeadline.qualified : subHeadline.unqualified}
+                    {qualifying?.toLowerCase() === 'true' ? subHeadline.qualified : subHeadline.unqualified}
                 </p>
                 <Icon name="icecream" />
                 <div className="thumbs-up">

--- a/src/components/modal/content/GB/parts/PL.jsx
+++ b/src/components/modal/content/GB/parts/PL.jsx
@@ -10,7 +10,7 @@ const headline = () => {
 
     const { qualifying } = useProductMeta('GPL');
 
-    if (qualifying !== 'TRUE') {
+    if (qualifying.toLowerCase() !== 'true') {
         return (
             <h1 className="offer">
                 {unqualified[0]} <br /> {unqualified[1]}
@@ -33,7 +33,9 @@ const PL = () => {
         <div className="content-body">
             <div className="left">
                 {headline()}
-                <p className="subheadline">{qualifying === 'TRUE' ? subHeadline.qualified : subHeadline.unqualified}</p>
+                <p className="subheadline">
+                    {qualifying.toLowerCase() === 'true' ? subHeadline.qualified : subHeadline.unqualified}
+                </p>
                 <Icon name="icecream" />
                 <div className="thumbs-up">
                     <Icon name="thumbs-up" />
@@ -59,7 +61,7 @@ const PL = () => {
                                 {text.map((textPart, idx) => (
                                     <Fragment>
                                         {idx !== 0 && textPart !== 'PRODUCT_NAME' ? <br /> : null}
-                                        {textPart === 'PRODUCT_NAME' ? <span>{productName}</span> : textPart}
+                                        {textPart === 'PRODUCT_NAME' ? <span> {productName}</span> : textPart}
                                     </Fragment>
                                 ))}
                             </p>

--- a/utils/devServerProxy/proxy.js
+++ b/utils/devServerProxy/proxy.js
@@ -205,7 +205,7 @@ export default (app, server, compiler) => {
                     .replace(/\${eval\(transaction_amount \? transaction_amount : '-'\)}/g, terms.amount ?? '-')
                     .replace(
                         /\${eval\(CREDIT_OFFERS_DS\.qualifying_offer \? CREDIT_OFFERS_DS\.qualifying_offer : 'false'\)}/g,
-                        terms.qualifying_offer
+                        morsVars.qualifying_offer
                     )
             );
 


### PR DESCRIPTION
Modifies the check against the `qualifying` attribute:
```
{
"qualifying": "${eval(CREDIT_OFFERS_DS.qualifying_offer ? CREDIT_OFFERS_DS.qualifying_offer : 'false')}"
}
```

to be case-insensitive allowing the modal to render the correct sub-headline.

Additionally adjusts development proxy which previously substituted `undefined` for the `qualifying` attribute.