### PR TITLE
ci: update config to better stabilize deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,13 @@ jobs:
 
         - stage: deploy
           env: TEST_PATH_PATTERN=none
-          # Override script so deploy doesn't run snapshot tests
+          # Overrides so deploy doesn't run these steps
+          before_script:
+              - true
           script:
+              - true
+          after_script:
+              - true
           deploy:
               provider: script
               skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,12 @@ jobs:
           deploy:
               provider: script
               skip_cleanup: true
+              # Unclear if these are redundant or not
+              before_script:
+                  - true
               script: npx semantic-release@15
+              after_script:
+                  - true
               on:
                   branch: release
 

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -49,6 +49,9 @@ module.exports = (env = {}) => {
     LIBRARY_DEV_CONFIG.devServer = {
         contentBase: './demo',
         publicPath: '/',
+        // set and export DEV_BROWSER in Terminal config to open that specific browser
+        // otherwise opens default browser if not set
+        open: process.env.DEV_BROWSER || true,
         openPage: (() => {
             switch (env.TARGET) {
                 case 'standalone':
@@ -61,7 +64,6 @@ module.exports = (env = {}) => {
         compress: true,
         host: 'localhost.paypal.com',
         port: PORT,
-        open: true,
         overlay: true,
         watchContentBase: true,
         injectClient: compiler => !!compiler.devServer,


### PR DESCRIPTION
According to [this page on bash statuses](https://www.cyberciti.biz/faq/linux-bash-exit-status-set-exit-statusin-bash/), `86` is `Streams pipe error`. Seems like this can occasionally happen with setting a field to empty in Travis CI config. So I'm adding `- true` to each empty step.

Also, since we don't need to run the dev server for a release, I've added empty step overrides for `before_script` and `after_script`.