### PR TITLE
feat: add flex background option, salmon

### DIFF
--- a/server/locale/US/PPC/styles/flex/color--salmon.css
+++ b/server/locale/US/PPC/styles/flex/color--salmon.css
@@ -1,0 +1,6 @@
+.message__background {
+    background: salmon;
+}
+.message__content {
+    color: white;
+}

--- a/server/locale/US/PPC/styles/flex/index.js
+++ b/server/locale/US/PPC/styles/flex/index.js
@@ -1,9 +1,11 @@
 import ratio1x1 from './ratio--1x1.css';
 import colorMonochrome from './color--monochrome.css';
 import colorGrayscale from './color--grayscale.css';
+import colorSalmon from './color--salmon.css';
 
 export default [
     ['ratio:1x1', ratio1x1],
     ['color:monochrome', colorMonochrome],
-    ['color:grayscale', colorGrayscale]
+    ['color:grayscale', colorGrayscale],
+    ['color:salmon', colorSalmon]
 ];

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -16,7 +16,7 @@ export default {
     flex: {
         color: [
             Types.STRING,
-            ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
+            ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale', 'salmon']
         ],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
         preset: [Types.STRING, [undefined, 'smallest']]


### PR DESCRIPTION
Add a flex option to allow merchants to hypothetically display PayPal Credit flex messages with a salmon background.