### PR TITLE
refactor: update text wrapping behavior for PPC messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 
 env:
     global:
-        - DIRTY_SNAPSHOTS=0
+        - DIRTY_SNAPSHOTS=1
     jobs:
         - TEST_PATH_PATTERN=none
 

--- a/server/locale/US/PPC/mutations/ezp_any_eqz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_eqz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 const defaultTextStyles = [
@@ -16,25 +16,26 @@ export default {
     'layout:text': [
         [
             'default',
-            {
-                styles: defaultTextStyles,
+            ({ textSize }) => ({
+                styles: [defaultTextStyles, textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'small',
                     br: ['APR']
                 },
                 disclaimer: 'xsmall.2'
-            }
+            })
         ],
         [
             'logo.type:primary',
-            {
+            ({ textSize }) => ({
+                styles: [textWrap(textSize * 38, textSize, 'US')],
                 headline: {
                     tag: 'small',
                     br: ['APR.'],
                     replace: [['APR', 'APR.']]
                 }
-            }
+            })
         ],
         [
             'logo.type:primary && logo.position:left',
@@ -45,16 +46,24 @@ export default {
                     ...defaultTextStyles,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -67,7 +76,8 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 35.8)
+                    altContentMediaQuery(textSize * 35.8),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -75,14 +85,22 @@ export default {
             'logo.type:inline',
             ({ textSize }) => ({
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
-                styles: [...defaultTextStyles, `.message__logo { width: ${textSize * 7}px }`]
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         ['logo.type:none', { logo: false }],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 messageWidth: [textSize * 15, 1000],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: {
@@ -97,26 +115,39 @@ export default {
                 styles: [
                     ...defaultTextStyles,
                     altContentMediaQuery(textSize * 35.8),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
             'logo.type:alternative && text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
             'logo.type:inline && text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo { width: ${textSize * 7}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -126,23 +157,31 @@ export default {
                     ...defaultTextStyles,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
                     }),
-                    ...whiteStyles
+                    ...whiteStyles,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:none && text.color:monochrome',
-            () => ({
-                styles: [...defaultTextStyles, `.tag--small { color: black; }`]
+            ({ textSize }) => ({
+                styles: [...defaultTextStyles, `.tag--small { color: black; }`, textWrap(textSize * 38, textSize, 'US')]
             })
         ],
         [
             'logo.type:none && text.color:grayscale',
-            () => ({
-                styles: [...defaultTextStyles, `.tag--small { color: #2c2e2f; }`]
+            ({ textSize }) => ({
+                styles: [
+                    ...defaultTextStyles,
+                    `.tag--small { color: #2c2e2f; }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ezp_any_eqz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_eqz.js
@@ -16,26 +16,25 @@ export default {
     'layout:text': [
         [
             'default',
-            () => ({
-                styles: [defaultTextStyles],
+            {
+                styles: defaultTextStyles,
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'small',
                     br: ['APR']
                 },
                 disclaimer: 'xsmall.2'
-            })
+            }
         ],
         [
             'logo.type:primary',
-            () => ({
-                styles: [],
+            {
                 headline: {
                     tag: 'small',
                     br: ['APR.'],
                     replace: [['APR', 'APR.']]
                 }
-            })
+            }
         ],
         [
             'logo.type:primary && logo.position:left',
@@ -46,10 +45,7 @@ export default {
                     ...defaultTextStyles,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     })
                 ]
@@ -89,7 +85,7 @@ export default {
                 styles: [
                     ...defaultTextStyles,
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ],
                 messageWidth: [textSize * 15, 1000],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
@@ -106,7 +102,7 @@ export default {
                     ...defaultTextStyles,
                     altContentMediaQuery(textSize * 35.8),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ]
             })
         ],
@@ -122,7 +118,7 @@ export default {
                 styles: [
                     ...whiteStyles,
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ]
             })
         ],
@@ -139,10 +135,7 @@ export default {
                     ...defaultTextStyles,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
                     ...whiteStyles

--- a/server/locale/US/PPC/mutations/ezp_any_eqz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_eqz.js
@@ -16,8 +16,8 @@ export default {
     'layout:text': [
         [
             'default',
-            ({ textSize }) => ({
-                styles: [defaultTextStyles, textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                styles: [defaultTextStyles],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'small',
@@ -28,8 +28,8 @@ export default {
         ],
         [
             'logo.type:primary',
-            ({ textSize }) => ({
-                styles: [textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                styles: [],
                 headline: {
                     tag: 'small',
                     br: ['APR.'],
@@ -51,19 +51,14 @@ export default {
                             largeLogo: textSize * 9
                         },
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    ...defaultTextStyles,
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -76,8 +71,7 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 35.8),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 35.8)
                 ]
             })
         ],
@@ -85,11 +79,7 @@ export default {
             'logo.type:inline',
             ({ textSize }) => ({
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
-                styles: [
-                    ...defaultTextStyles,
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...defaultTextStyles, `.message__logo { width: ${textSize * 7}px }`]
             })
         ],
         ['logo.type:none', { logo: false }],
@@ -123,11 +113,7 @@ export default {
         [
             'text.color:white',
             ({ textSize }) => ({
-                styles: [
-                    ...whiteStyles,
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -143,11 +129,7 @@ export default {
         [
             'logo.type:inline && text.color:white',
             ({ textSize }) => ({
-                styles: [
-                    ...whiteStyles,
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...whiteStyles, `.message__logo { width: ${textSize * 7}px }`]
             })
         ],
         [
@@ -163,25 +145,20 @@ export default {
                         },
                         whiteSpaceBP: textSize * 27
                     }),
-                    ...whiteStyles,
-                    textWrap(textSize * 38, textSize, 'US')
+                    ...whiteStyles
                 ]
             })
         ],
         [
             'logo.type:none && text.color:monochrome',
-            ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.tag--small { color: black; }`, textWrap(textSize * 38, textSize, 'US')]
+            () => ({
+                styles: [...defaultTextStyles, `.tag--small { color: black; }`]
             })
         ],
         [
             'logo.type:none && text.color:grayscale',
-            ({ textSize }) => ({
-                styles: [
-                    ...defaultTextStyles,
-                    `.tag--small { color: #2c2e2f; }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+            () => ({
+                styles: [...defaultTextStyles, `.tag--small { color: #2c2e2f; }`]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ezp_any_eqz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_eqz.js
@@ -107,6 +107,12 @@ export default {
             })
         ],
         [
+            'logo.type:alternative && logo.position:top',
+            ({ textSize }) => ({
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+            })
+        ],
+        [
             'text.color:white',
             ({ textSize }) => ({
                 styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]

--- a/server/locale/US/PPC/mutations/ezp_any_gtz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_gtz.js
@@ -16,8 +16,8 @@ export default {
     'layout:text': [
         [
             'default',
-            () => ({
-                styles: [defaultTextStyles],
+            {
+                styles: defaultTextStyles,
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'xsmall',
@@ -25,7 +25,7 @@ export default {
                     br: ['months.']
                 },
                 disclaimer: 'xsmall.2'
-            })
+            }
         ],
         [
             'logo.type:primary && logo.position:left',
@@ -77,15 +77,14 @@ export default {
         ],
         [
             'logo.type:none',
-            () => ({
-                styles: [],
+            {
                 logo: false,
                 headline: {
                     tag: 'xsmall',
                     replace: [['months.', 'months']],
                     br: ['months']
                 }
-            })
+            }
         ],
         [
             'logo.type:alternative',
@@ -93,7 +92,7 @@ export default {
                 styles: [
                     ...defaultTextStyles,
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: {
@@ -107,9 +106,10 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     ...defaultTextStyles,
+
                     altContentMediaQuery(textSize * 30.6),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ]
             })
         ],
@@ -125,7 +125,7 @@ export default {
                 styles: [
                     ...whiteStyles,
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ]
             })
         ],

--- a/server/locale/US/PPC/mutations/ezp_any_gtz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_gtz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 const defaultTextStyles = [
@@ -16,8 +16,8 @@ export default {
     'layout:text': [
         [
             'default',
-            {
-                styles: defaultTextStyles,
+            ({ textSize }) => ({
+                styles: [defaultTextStyles, textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'xsmall',
@@ -25,7 +25,7 @@ export default {
                     br: ['months.']
                 },
                 disclaimer: 'xsmall.2'
-            }
+            })
         ],
         [
             'logo.type:primary && logo.position:left',
@@ -39,14 +39,19 @@ export default {
                         width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
-                    '.message__messaging span.br { white-space: nowrap; }'
+                    '.message__messaging span.br { white-space: nowrap; }',
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -59,14 +64,19 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 30.6)
+                    altContentMediaQuery(textSize * 30.6),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.message__logo { width: ${textSize * 7}px }`],
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 headline: {
                     tag: 'xsmall',
                     replace: [['months.', 'months']],
@@ -77,19 +87,24 @@ export default {
         ],
         [
             'logo.type:none',
-            {
+            ({ textSize }) => ({
+                style: [textWrap(textSize * 38, textSize, 'US')],
                 logo: false,
                 headline: {
                     tag: 'xsmall',
                     replace: [['months.', 'months']],
                     br: ['months']
                 }
-            }
+            })
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    ...defaultTextStyles,
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: {
                     replace: [['months', 'months.']],
@@ -102,28 +117,40 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     ...defaultTextStyles,
-
                     altContentMediaQuery(textSize * 30.6),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
             'logo.type:alternative && text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
             'logo.type:inline && text.color:white',
             ({ textSize }) => ({
-                styles: [...whiteStyles, `.message__logo { width: ${textSize * 7}px }`]
+                styles: [
+                    ...whiteStyles,
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -137,20 +164,25 @@ export default {
                         whiteSpaceBP: textSize * 27
                     }),
                     '.message__messaging span.br { white-space: nowrap; }',
-                    ...whiteStyles
+                    ...whiteStyles,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:none && text.color:monochrome',
-            () => ({
-                styles: [...defaultTextStyles, `.tag--small { color: black; }`]
+            ({ textSize }) => ({
+                styles: [...defaultTextStyles, `.tag--small { color: black; }`, textWrap(textSize * 38, textSize, 'US')]
             })
         ],
         [
             'logo.type:none && text.color:grayscale',
-            () => ({
-                styles: [...defaultTextStyles, `.tag--small { color: #2c2e2f; }`]
+            ({ textSize }) => ({
+                styles: [
+                    ...defaultTextStyles,
+                    `.tag--small { color: #2c2e2f; }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ezp_any_gtz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_gtz.js
@@ -16,8 +16,8 @@ export default {
     'layout:text': [
         [
             'default',
-            ({ textSize }) => ({
-                styles: [defaultTextStyles, textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                styles: [defaultTextStyles],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: {
                     tag: 'xsmall',
@@ -39,19 +39,14 @@ export default {
                         width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
-                    '.message__messaging span.br { white-space: nowrap; }',
-                    textWrap(textSize * 38, textSize, 'US')
+                    '.message__messaging span.br { white-space: nowrap; }'
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    ...defaultTextStyles,
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...defaultTextStyles, `.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -64,19 +59,14 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 30.6),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 30.6)
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [
-                    ...defaultTextStyles,
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ],
+                styles: [...defaultTextStyles, `.message__logo { width: ${textSize * 7}px }`],
                 headline: {
                     tag: 'xsmall',
                     replace: [['months.', 'months']],
@@ -87,8 +77,8 @@ export default {
         ],
         [
             'logo.type:none',
-            ({ textSize }) => ({
-                style: [textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                styles: [],
                 logo: false,
                 headline: {
                     tag: 'xsmall',
@@ -126,11 +116,7 @@ export default {
         [
             'text.color:white',
             ({ textSize }) => ({
-                styles: [
-                    ...whiteStyles,
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -146,11 +132,7 @@ export default {
         [
             'logo.type:inline && text.color:white',
             ({ textSize }) => ({
-                styles: [
-                    ...whiteStyles,
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [...whiteStyles, `.message__logo { width: ${textSize * 7}px }`]
             })
         ],
         [
@@ -164,25 +146,20 @@ export default {
                         whiteSpaceBP: textSize * 27
                     }),
                     '.message__messaging span.br { white-space: nowrap; }',
-                    ...whiteStyles,
-                    textWrap(textSize * 38, textSize, 'US')
+                    ...whiteStyles
                 ]
             })
         ],
         [
             'logo.type:none && text.color:monochrome',
-            ({ textSize }) => ({
-                styles: [...defaultTextStyles, `.tag--small { color: black; }`, textWrap(textSize * 38, textSize, 'US')]
+            () => ({
+                styles: [...defaultTextStyles, `.tag--small { color: black; }`]
             })
         ],
         [
             'logo.type:none && text.color:grayscale',
-            ({ textSize }) => ({
-                styles: [
-                    ...defaultTextStyles,
-                    `.tag--small { color: #2c2e2f; }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+            () => ({
+                styles: [...defaultTextStyles, `.tag--small { color: #2c2e2f; }`]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ezp_any_gtz.js
+++ b/server/locale/US/PPC/mutations/ezp_any_gtz.js
@@ -114,6 +114,12 @@ export default {
             })
         ],
         [
+            'logo.type:alternative && logo.position:top',
+            ({ textSize }) => ({
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+            })
+        ],
+        [
             'text.color:white',
             ({ textSize }) => ({
                 styles: [...whiteStyles, `.message__logo-container { width: ${textSize * 9}px }`]

--- a/server/locale/US/PPC/mutations/mediaQueries.js
+++ b/server/locale/US/PPC/mutations/mediaQueries.js
@@ -104,3 +104,21 @@ export function messageDisclaimerMediaQuery(breakpoint) {
     }
     `;
 }
+export function textWrap(breakpoint, textSize, locale) {
+    return `@media screen and (max-width: ${breakpoint}px) {
+        .locale--${locale} .message__content {
+            display: block;
+            margin-top: -${(textSize / 2) * 0}px;
+        }
+        .locale--${locale} .message__logo-container {
+            display: inline-flex;
+            transform: translateY(${(textSize / 2) * 0}px);
+        }
+        .locale--${locale} .message__messaging {
+            display: inline;
+        }
+        .locale--${locale} .message__messaging span.br:first-child {
+            white-space: normal;
+        }
+    }`;
+}

--- a/server/locale/US/PPC/mutations/ni.js
+++ b/server/locale/US/PPC/mutations/ni.js
@@ -180,11 +180,7 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    basicMediaQuery(textSize * 18.5),
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 39, textSize, 'US')
-                ]
+                styles: [basicMediaQuery(textSize * 18.5), `.message__logo-container { width: ${textSize * 5}px }`]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ni.js
+++ b/server/locale/US/PPC/mutations/ni.js
@@ -3,7 +3,8 @@ import {
     basicMediaQuery,
     altContentMediaQuery,
     primaryContentMediaQuery,
-    messageDisclaimerMediaQuery
+    messageDisclaimerMediaQuery,
+    textWrap
 } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
@@ -46,7 +47,11 @@ export default {
             ({ textSize }) => {
                 const breakpointCalc = textSize * 19 + 70;
                 return {
-                    styles: [messageDisclaimerMediaQuery(breakpointCalc - 1), [basicMediaQuery(breakpointCalc)]],
+                    styles: [
+                        messageDisclaimerMediaQuery(breakpointCalc - 1),
+                        [basicMediaQuery(breakpointCalc)],
+                        textWrap(textSize * 38, textSize, 'US')
+                    ],
                     logo: Logo.SINGLE_LINE.COLOR,
                     headline: [
                         { tag: 'xsmall', br: ['time.'] },
@@ -73,7 +78,8 @@ export default {
                         display: inline;
                     }
                     `,
-                    altContentMediaQuery(textSize * 43.5)
+                    altContentMediaQuery(textSize * 43.5),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -90,17 +96,25 @@ export default {
                     basicMediaQuery(textSize * 18),
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 15 + 80), `.message__logo { width: ${textSize * 7}px }`],
+                styles: [
+                    basicMediaQuery(textSize * 15 + 80),
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
                     {
@@ -119,7 +133,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 20)],
+                styles: [basicMediaQuery(textSize * 20), textWrap(textSize * 38, textSize, 'US')],
                 logo: false,
                 headline: [
                     {
@@ -138,7 +152,11 @@ export default {
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 18), `.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    basicMediaQuery(textSize * 18),
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
         ],
@@ -148,7 +166,8 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 18),
                     altContentMediaQuery(textSize * 42),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -166,7 +185,8 @@ export default {
                             display:block;
                         }
                         `,
-                        `.message__logo-container { width: ${textSize * 9}px }`
+                        `.message__logo-container { width: ${textSize * 9}px }`,
+                        textWrap(textSize * 38, textSize, 'US')
                     ]
                 };
             }
@@ -174,7 +194,11 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 18.5), `.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    basicMediaQuery(textSize * 18.5),
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         ...textLogoMutations

--- a/server/locale/US/PPC/mutations/ni.js
+++ b/server/locale/US/PPC/mutations/ni.js
@@ -91,10 +91,7 @@ export default {
                     basicMediaQuery(textSize * 18),
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
                     })
@@ -145,7 +142,7 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 18),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 39, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -157,7 +154,7 @@ export default {
                     basicMediaQuery(textSize * 18),
                     altContentMediaQuery(textSize * 42),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 39, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -186,7 +183,7 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 18.5),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 39, textSize, 'US')
                 ]
             })
         ],

--- a/server/locale/US/PPC/mutations/ni.js
+++ b/server/locale/US/PPC/mutations/ni.js
@@ -47,11 +47,7 @@ export default {
             ({ textSize }) => {
                 const breakpointCalc = textSize * 19 + 70;
                 return {
-                    styles: [
-                        messageDisclaimerMediaQuery(breakpointCalc - 1),
-                        [basicMediaQuery(breakpointCalc)],
-                        textWrap(textSize * 38, textSize, 'US')
-                    ],
+                    styles: [messageDisclaimerMediaQuery(breakpointCalc - 1), [basicMediaQuery(breakpointCalc)]],
                     logo: Logo.SINGLE_LINE.COLOR,
                     headline: [
                         { tag: 'xsmall', br: ['time.'] },
@@ -78,8 +74,7 @@ export default {
                         display: inline;
                     }
                     `,
-                    altContentMediaQuery(textSize * 43.5),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 43.5)
                 ]
             })
         ],
@@ -102,19 +97,14 @@ export default {
                         },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [
-                    basicMediaQuery(textSize * 15 + 80),
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ],
+                styles: [basicMediaQuery(textSize * 15 + 80), `.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
                     {
@@ -133,7 +123,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 20), textWrap(textSize * 38, textSize, 'US')],
+                styles: [basicMediaQuery(textSize * 20)],
                 logo: false,
                 headline: [
                     {
@@ -185,8 +175,7 @@ export default {
                             display:block;
                         }
                         `,
-                        `.message__logo-container { width: ${textSize * 9}px }`,
-                        textWrap(textSize * 38, textSize, 'US')
+                        `.message__logo-container { width: ${textSize * 9}px }`
                     ]
                 };
             }

--- a/server/locale/US/PPC/mutations/ni_non-us.js
+++ b/server/locale/US/PPC/mutations/ni_non-us.js
@@ -47,11 +47,7 @@ export default {
             ({ textSize }) => {
                 const breakpointCalc = textSize * 22 + 70;
                 return {
-                    styles: [
-                        messageDisclaimerMediaQuery(breakpointCalc - 1),
-                        basicMediaQuery(breakpointCalc),
-                        textWrap(textSize * 38, textSize, 'US')
-                    ],
+                    styles: [messageDisclaimerMediaQuery(breakpointCalc - 1), basicMediaQuery(breakpointCalc)],
                     logo: Logo.SINGLE_LINE.COLOR,
                     headline: [
                         { tag: 'xsmall', br: ['time.'] },
@@ -87,19 +83,14 @@ export default {
                             largeLogo: textSize * 9
                         },
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [
-                    basicMediaQuery(textSize * 23),
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ],
+                styles: [basicMediaQuery(textSize * 23), `.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
                     {
@@ -114,7 +105,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 21), textWrap(textSize * 38, textSize, 'US')],
+                styles: [basicMediaQuery(textSize * 21)],
                 logo: false,
                 headline: [
                     {
@@ -158,7 +149,8 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    `.message__headline span:only-child { white-space: nowrap; }`
+                    `.message__headline span:only-child { white-space: nowrap; }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 headline: [
                     'xsmall',
@@ -176,7 +168,8 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 45),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/ni_non-us.js
+++ b/server/locale/US/PPC/mutations/ni_non-us.js
@@ -111,10 +111,10 @@ export default {
                 const breakpointCalc = textSize * 17;
                 return {
                     styles: [
-                        messageDisclaimerMediaQuery(breakpointCalc - 1),
                         basicMediaQuery(breakpointCalc),
                         `.message__logo-container { width: ${textSize * 5}px }`,
-                        textWrap(textSize * 43, textSize, 'US')
+                        textWrap(textSize * 43, textSize, 'US'),
+                        `.message__headline span:only-child { white-space: normal; }`
                     ],
                     logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                     headline: [
@@ -134,8 +134,7 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    `.message__headline span:only-child { white-space: nowrap; }`,
-                    textWrap(textSize * 43, textSize, 'US')
+                    `.message__headline span:only-child { white-space: nowrap; }`
                 ],
                 headline: [
                     'xsmall',
@@ -154,7 +153,8 @@ export default {
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 45),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 43, textSize, 'US')
+                    textWrap(textSize * 43, textSize, 'US'),
+                    `.message__headline span:only-child { white-space: normal; }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/ni_non-us.js
+++ b/server/locale/US/PPC/mutations/ni_non-us.js
@@ -3,7 +3,8 @@ import {
     basicMediaQuery,
     altContentMediaQuery,
     primaryContentMediaQuery,
-    messageDisclaimerMediaQuery
+    messageDisclaimerMediaQuery,
+    textWrap
 } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
@@ -46,11 +47,19 @@ export default {
             ({ textSize }) => {
                 const breakpointCalc = textSize * 22 + 70;
                 return {
-                    styles: [messageDisclaimerMediaQuery(breakpointCalc - 1), basicMediaQuery(breakpointCalc)],
+                    styles: [
+                        messageDisclaimerMediaQuery(breakpointCalc - 1),
+                        basicMediaQuery(breakpointCalc),
+                        textWrap(textSize * 38, textSize, 'US')
+                    ],
                     logo: Logo.SINGLE_LINE.COLOR,
                     headline: [
                         { tag: 'xsmall', br: ['time.'] },
-                        { tag: 'medium', br: ['months'], replace: [['99+', '99+.']] }
+                        {
+                            tag: 'medium',
+                            br: ['months'],
+                            replace: [['99+', '99+.']]
+                        }
                     ],
                     disclaimer: ['extra', 'xsmall']
                 };
@@ -63,25 +72,41 @@ export default {
                 logo: [Logo.SINGLE_LINE_NO_PAYPAL.COLOR, Logo.SINGLE_LINE.COLOR],
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    { tag: 'medium', br: ['on '], replace: [['99+', '99+.']] }
+                    {
+                        tag: 'medium',
+                        br: ['on '],
+                        replace: [['99+', '99+.']]
+                    }
                 ],
                 styles: [
                     basicMediaQuery(textSize * 18),
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 23), `.message__logo { width: ${textSize * 7}px }`],
+                styles: [
+                    basicMediaQuery(textSize * 23),
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
+                    {
+                        tag: 'xsmall',
+                        replace: [['time.', 'time']],
+                        br: ['time']
+                    },
                     { tag: 'medium', br: ['purchases'] }
                 ]
             })
@@ -89,7 +114,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [basicMediaQuery(textSize * 21)],
+                styles: [basicMediaQuery(textSize * 21), textWrap(textSize * 38, textSize, 'US')],
                 logo: false,
                 headline: [
                     {
@@ -112,7 +137,8 @@ export default {
                     styles: [
                         messageDisclaimerMediaQuery(breakpointCalc - 1),
                         basicMediaQuery(breakpointCalc),
-                        `.message__logo-container { width: ${textSize * 5}px }`
+                        `.message__logo-container { width: ${textSize * 5}px }`,
+                        textWrap(textSize * 38, textSize, 'US')
                     ],
                     logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                     headline: [

--- a/server/locale/US/PPC/mutations/ni_non-us.js
+++ b/server/locale/US/PPC/mutations/ni_non-us.js
@@ -51,11 +51,7 @@ export default {
                     logo: Logo.SINGLE_LINE.COLOR,
                     headline: [
                         { tag: 'xsmall', br: ['time.'] },
-                        {
-                            tag: 'medium',
-                            br: ['months'],
-                            replace: [['99+', '99+.']]
-                        }
+                        { tag: 'medium', br: ['months'], replace: [['99+', '99+.']] }
                     ],
                     disclaimer: ['extra', 'xsmall']
                 };
@@ -68,20 +64,13 @@ export default {
                 logo: [Logo.SINGLE_LINE_NO_PAYPAL.COLOR, Logo.SINGLE_LINE.COLOR],
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    {
-                        tag: 'medium',
-                        br: ['on '],
-                        replace: [['99+', '99+.']]
-                    }
+                    { tag: 'medium', br: ['on '], replace: [['99+', '99+.']] }
                 ],
                 styles: [
                     basicMediaQuery(textSize * 18),
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     })
                 ]
@@ -93,11 +82,7 @@ export default {
                 styles: [basicMediaQuery(textSize * 23), `.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    {
-                        tag: 'xsmall',
-                        replace: [['time.', 'time']],
-                        br: ['time']
-                    },
+                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
                     { tag: 'medium', br: ['purchases'] }
                 ]
             })
@@ -129,7 +114,7 @@ export default {
                         messageDisclaimerMediaQuery(breakpointCalc - 1),
                         basicMediaQuery(breakpointCalc),
                         `.message__logo-container { width: ${textSize * 5}px }`,
-                        textWrap(textSize * 38, textSize, 'US')
+                        textWrap(textSize * 43, textSize, 'US')
                     ],
                     logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                     headline: [
@@ -150,7 +135,7 @@ export default {
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
                     `.message__headline span:only-child { white-space: nowrap; }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 43, textSize, 'US')
                 ],
                 headline: [
                     'xsmall',
@@ -169,7 +154,7 @@ export default {
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 45),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 43, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq.js
+++ b/server/locale/US/PPC/mutations/niq.js
@@ -19,11 +19,7 @@ export default {
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    {
-                        tag: 'medium',
-                        br: ['months.'],
-                        replace: [['months', 'months.']]
-                    }
+                    { tag: 'medium', br: ['months.'], replace: [['months', 'months.']] }
                 ],
                 disclaimer: 'xsmall'
             })
@@ -42,10 +38,7 @@ export default {
                     `,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
                     })
@@ -64,11 +57,7 @@ export default {
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    {
-                        tag: 'xsmall',
-                        replace: [['time.', 'time']],
-                        br: ['time']
-                    },
+                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
                     { tag: 'medium', br: ['months'] }
                 ]
             })
@@ -105,7 +94,7 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 18),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 30, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -140,7 +129,7 @@ export default {
                     }
                     `,
                     basicMediaQuery(textSize * 18.5),
-                    altContentMediaQuery(textSize * 33),
+                    altContentMediaQuery(textSize * 30),
                     `.message__logo-container { width: ${textSize * 9}px }`
                 ]
             })
@@ -154,7 +143,7 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 18.5),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 30, textSize, 'US')
                 ]
             })
         ],
@@ -165,7 +154,7 @@ export default {
                     basicMediaQuery(textSize * 18.5),
                     altContentMediaQuery(textSize * 33),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 30, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq.js
+++ b/server/locale/US/PPC/mutations/niq.js
@@ -1,6 +1,6 @@
 import Logo from '../logos';
 import { flex } from './ni';
-import { basicMediaQuery, altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { basicMediaQuery, altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations } from './common';
 
 export default {
@@ -14,12 +14,17 @@ export default {
                         display:none;
                     }
                    `,
-                    [basicMediaQuery(textSize * 18.5 + 70)]
+                    [basicMediaQuery(textSize * 18.5 + 70)],
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    { tag: 'medium', br: ['months.'], replace: [['months', 'months.']] }
+                    {
+                        tag: 'medium',
+                        br: ['months.'],
+                        replace: [['months', 'months.']]
+                    }
                 ],
                 disclaimer: 'xsmall'
             })
@@ -38,10 +43,14 @@ export default {
                     `,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -53,11 +62,16 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 12 + 80),
-                    `.message__logo { width: ${textSize * 7}px }`
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
+                    {
+                        tag: 'xsmall',
+                        replace: [['time.', 'time']],
+                        br: ['time']
+                    },
                     { tag: 'medium', br: ['months'] }
                 ]
             })
@@ -69,7 +83,8 @@ export default {
                     `.weak {
                         display:none;
                     }`,
-                    basicMediaQuery(textSize * 17)
+                    basicMediaQuery(textSize * 17),
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: false,
                 headline: [
@@ -93,7 +108,8 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -111,7 +127,8 @@ export default {
                     }
                     `,
                     `.message__logo-container { width: ${textSize * 9}px }`,
-                    basicMediaQuery(textSize * 18.5)
+                    basicMediaQuery(textSize * 18.5),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -129,7 +146,8 @@ export default {
                     `,
                     basicMediaQuery(textSize * 18.5),
                     altContentMediaQuery(textSize * 33),
-                    `.message__logo-container { width: ${textSize * 9}px }`
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -141,7 +159,8 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18.5),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -151,7 +170,8 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 18.5),
                     altContentMediaQuery(textSize * 33),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq.js
+++ b/server/locale/US/PPC/mutations/niq.js
@@ -142,8 +142,7 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18.5),
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 30, textSize, 'US')
+                    `.message__logo-container { width: ${textSize * 5}px }`
                 ]
             })
         ],
@@ -152,9 +151,9 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     basicMediaQuery(textSize * 18.5),
-                    altContentMediaQuery(textSize * 33),
+                    altContentMediaQuery(textSize * 42),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 30, textSize, 'US')
+                    textWrap(textSize * 40, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq.js
+++ b/server/locale/US/PPC/mutations/niq.js
@@ -14,8 +14,7 @@ export default {
                         display:none;
                     }
                    `,
-                    [basicMediaQuery(textSize * 18.5 + 70)],
-                    textWrap(textSize * 38, textSize, 'US')
+                    [basicMediaQuery(textSize * 18.5 + 70)]
                 ],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
@@ -49,8 +48,7 @@ export default {
                         },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
@@ -62,8 +60,7 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 12 + 80),
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `.message__logo { width: ${textSize * 7}px }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
@@ -83,8 +80,7 @@ export default {
                     `.weak {
                         display:none;
                     }`,
-                    basicMediaQuery(textSize * 17),
-                    textWrap(textSize * 38, textSize, 'US')
+                    basicMediaQuery(textSize * 17)
                 ],
                 logo: false,
                 headline: [
@@ -127,8 +123,7 @@ export default {
                     }
                     `,
                     `.message__logo-container { width: ${textSize * 9}px }`,
-                    basicMediaQuery(textSize * 18.5),
-                    textWrap(textSize * 38, textSize, 'US')
+                    basicMediaQuery(textSize * 18.5)
                 ]
             })
         ],
@@ -146,8 +141,7 @@ export default {
                     `,
                     basicMediaQuery(textSize * 18.5),
                     altContentMediaQuery(textSize * 33),
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `.message__logo-container { width: ${textSize * 9}px }`
                 ]
             })
         ],

--- a/server/locale/US/PPC/mutations/niq_non-us.js
+++ b/server/locale/US/PPC/mutations/niq_non-us.js
@@ -95,7 +95,8 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 18),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 34, textSize, 'US')
+                    textWrap(textSize * 34, textSize, 'US'),
+                    `.message__headline span:only-child { white-space: normal; }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: [
@@ -117,8 +118,7 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    `.message__headline span:only-child { white-space: nowrap; }`,
-                    textWrap(textSize * 34, textSize, 'US')
+                    `.message__headline span:only-child { white-space: nowrap; }`
                 ],
                 headline: [
                     'xsmall',
@@ -137,7 +137,8 @@ export default {
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 35),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 34, textSize, 'US')
+                    textWrap(textSize * 34, textSize, 'US'),
+                    `.message__headline span:only-child { white-space: normal; }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq_non-us.js
+++ b/server/locale/US/PPC/mutations/niq_non-us.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { basicMediaQuery, altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { basicMediaQuery, altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { flex } from './ni_non-us';
 import { textLogoMutations } from './common';
 
@@ -15,12 +15,17 @@ export default {
                     .message__disclaimer {
                         display:block;
                     }`,
-                    basicMediaQuery(textSize * 18.5 + 70)
+                    basicMediaQuery(textSize * 18.5 + 70),
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    { tag: 'medium', br: ['months.'], replace: [['months', 'months.']] }
+                    {
+                        tag: 'medium',
+                        br: ['months.'],
+                        replace: [['months', 'months.']]
+                    }
                 ],
                 disclaimer: ['extra', 'xsmall']
             })
@@ -39,10 +44,14 @@ export default {
                     `,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -54,11 +63,16 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18),
-                    `.message__logo { width: ${textSize * 7}px }`
+                    `.message__logo { width: ${textSize * 7}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
+                    {
+                        tag: 'xsmall',
+                        replace: [['time.', 'time']],
+                        br: ['time']
+                    },
                     { tag: 'medium', br: ['purchases'] }
                 ]
             })
@@ -70,7 +84,8 @@ export default {
                     `.weak {
                         display:none;
                     }`,
-                    basicMediaQuery(textSize * 18)
+                    basicMediaQuery(textSize * 18),
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: false,
                 headline: [
@@ -94,7 +109,8 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: [
@@ -116,7 +132,8 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    `.message__headline span:only-child { white-space: nowrap; }`
+                    `.message__headline span:only-child { white-space: nowrap; }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 headline: [
                     'xsmall',
@@ -134,7 +151,8 @@ export default {
                 styles: [
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 35),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -150,7 +168,8 @@ export default {
                         display:block;
                     }`,
                     `.message__logo-container { width: ${textSize * 9}px }`,
-                    basicMediaQuery(textSize * 18)
+                    basicMediaQuery(textSize * 18),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -165,7 +184,8 @@ export default {
                     .message__content { display: inline-block; }
                     `,
                     basicMediaQuery(textSize * 18),
-                    altContentMediaQuery(textSize * 37)
+                    altContentMediaQuery(textSize * 37),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],

--- a/server/locale/US/PPC/mutations/niq_non-us.js
+++ b/server/locale/US/PPC/mutations/niq_non-us.js
@@ -15,8 +15,7 @@ export default {
                     .message__disclaimer {
                         display:block;
                     }`,
-                    basicMediaQuery(textSize * 18.5 + 70),
-                    textWrap(textSize * 38, textSize, 'US')
+                    basicMediaQuery(textSize * 18.5 + 70)
                 ],
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
@@ -50,8 +49,7 @@ export default {
                         },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
@@ -63,8 +61,7 @@ export default {
                         display:none;
                     }`,
                     basicMediaQuery(textSize * 18),
-                    `.message__logo { width: ${textSize * 7}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `.message__logo { width: ${textSize * 7}px }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
@@ -84,8 +81,7 @@ export default {
                     `.weak {
                         display:none;
                     }`,
-                    basicMediaQuery(textSize * 18),
-                    textWrap(textSize * 38, textSize, 'US')
+                    basicMediaQuery(textSize * 18)
                 ],
                 logo: false,
                 headline: [
@@ -168,8 +164,7 @@ export default {
                         display:block;
                     }`,
                     `.message__logo-container { width: ${textSize * 9}px }`,
-                    basicMediaQuery(textSize * 18),
-                    textWrap(textSize * 38, textSize, 'US')
+                    basicMediaQuery(textSize * 18)
                 ]
             })
         ],
@@ -184,8 +179,7 @@ export default {
                     .message__content { display: inline-block; }
                     `,
                     basicMediaQuery(textSize * 18),
-                    altContentMediaQuery(textSize * 37),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 37)
                 ]
             })
         ],

--- a/server/locale/US/PPC/mutations/niq_non-us.js
+++ b/server/locale/US/PPC/mutations/niq_non-us.js
@@ -20,11 +20,7 @@ export default {
                 logo: Logo.SINGLE_LINE.COLOR,
                 headline: [
                     { tag: 'xsmall', br: ['time.'] },
-                    {
-                        tag: 'medium',
-                        br: ['months.'],
-                        replace: [['months', 'months.']]
-                    }
+                    { tag: 'medium', br: ['months.'], replace: [['months', 'months.']] }
                 ],
                 disclaimer: ['extra', 'xsmall']
             })
@@ -43,10 +39,7 @@ export default {
                     `,
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         logoSvgBP: textSize * 41.75,
                         whiteSpaceBP: textSize * 27
                     })
@@ -65,11 +58,7 @@ export default {
                 ],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: [
-                    {
-                        tag: 'xsmall',
-                        replace: [['time.', 'time']],
-                        br: ['time']
-                    },
+                    { tag: 'xsmall', replace: [['time.', 'time']], br: ['time'] },
                     { tag: 'medium', br: ['purchases'] }
                 ]
             })
@@ -106,7 +95,7 @@ export default {
                     }`,
                     basicMediaQuery(textSize * 18),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 34, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 headline: [
@@ -129,7 +118,7 @@ export default {
                     basicMediaQuery(textSize * 20),
                     `.message__logo-container { width: ${textSize * 5}px }`,
                     `.message__headline span:only-child { white-space: nowrap; }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 34, textSize, 'US')
                 ],
                 headline: [
                     'xsmall',
@@ -148,7 +137,7 @@ export default {
                     basicMediaQuery(textSize * 20),
                     altContentMediaQuery(textSize * 35),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 34, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/niq_non-us.js
+++ b/server/locale/US/PPC/mutations/niq_non-us.js
@@ -135,7 +135,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     basicMediaQuery(textSize * 20),
-                    altContentMediaQuery(textSize * 35),
+                    altContentMediaQuery(textSize * 42),
                     `.message__logo-container { width: ${textSize * 5}px }`,
                     textWrap(textSize * 34, textSize, 'US'),
                     `.message__headline span:only-child { white-space: normal; }`

--- a/server/locale/US/PPC/mutations/pala_multi_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_eqz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 export default {
@@ -7,6 +7,7 @@ export default {
         [
             'default',
             ({ textSize }) => ({
+                styles: [textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 11, textSize * 18],
                 headline: {
@@ -23,21 +24,28 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
                     @media (max-width: ${textSize * 11}px) {
                         .message__messaging { display: block; }
                     }
-                    `
+                    `,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -49,14 +57,15 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3)
+                    altContentMediaQuery(textSize * 34.3),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`],
+                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: [textSize * 19, 1000],
                 headline: {
@@ -68,6 +77,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
+                styles: [textWrap(textSize * 38, textSize, 'US')],
                 logo: false,
                 messageWidth: [textSize * 17, 1000],
                 headline: {
@@ -79,7 +89,10 @@ export default {
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -87,7 +100,10 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -95,7 +111,8 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     altContentMediaQuery(textSize * 29.1),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_multi_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_eqz.js
@@ -7,7 +7,6 @@ export default {
         [
             'default',
             ({ textSize }) => ({
-                styles: [],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 11, textSize * 18],
                 headline: {
@@ -24,10 +23,7 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
@@ -72,7 +68,6 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [],
                 logo: false,
                 messageWidth: [textSize * 17, 1000],
                 headline: {
@@ -86,7 +81,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 27, textSize, 'US')
                 ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
@@ -97,7 +92,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 27, textSize, 'US')
                 ]
             })
         ],
@@ -107,7 +102,7 @@ export default {
                 styles: [
                     altContentMediaQuery(textSize * 29.1),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 27, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_multi_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_eqz.js
@@ -7,7 +7,7 @@ export default {
         [
             'default',
             ({ textSize }) => ({
-                styles: [textWrap(textSize * 38, textSize, 'US')],
+                styles: [],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 11, textSize * 18],
                 headline: {
@@ -34,18 +34,14 @@ export default {
                     @media (max-width: ${textSize * 11}px) {
                         .message__messaging { display: block; }
                     }
-                    `,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -57,15 +53,14 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 34.3)
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
+                styles: [`.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: [textSize * 19, 1000],
                 headline: {
@@ -77,7 +72,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [textWrap(textSize * 38, textSize, 'US')],
+                styles: [],
                 logo: false,
                 messageWidth: [textSize * 17, 1000],
                 headline: {

--- a/server/locale/US/PPC/mutations/pala_multi_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_eqz.js
@@ -90,10 +90,7 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 27, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
             })
         ],
         [

--- a/server/locale/US/PPC/mutations/pala_multi_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_gtz.js
@@ -71,7 +71,8 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 22, textSize, 'US')
+                    textWrap(textSize * 22, textSize, 'US'),
+                    `.message__headline span:only-child { white-space: normal; }`
                 ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
@@ -80,10 +81,7 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 22, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
             })
         ],
         [

--- a/server/locale/US/PPC/mutations/pala_multi_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_gtz.js
@@ -11,16 +11,13 @@ export default {
                 messageWidth: [textSize * 11, textSize * 12],
                 headline: { tag: 'xsmall' },
                 disclaimer: 'xsmall',
-                styles: [textWrap(textSize * 38, textSize, 'US')]
+                styles: []
             })
         ],
         [
             'logo.type:primary',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -35,8 +32,7 @@ export default {
                             largeLogo: textSize * 9
                         },
                         whiteSpaceBP: textSize * 27
-                    }),
-                    textWrap(textSize * 38, textSize, 'US')
+                    })
                 ]
             })
         ],
@@ -49,15 +45,14 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 34.3)
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
+                styles: [`.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: false,
                 headline: {
@@ -67,8 +62,8 @@ export default {
         ],
         [
             'logo.type:none',
-            ({ textSize }) => ({
-                style: [textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                style: [],
                 logo: false,
                 messageWidth: false,
                 headline: {

--- a/server/locale/US/PPC/mutations/pala_multi_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_gtz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 export default {
@@ -10,13 +10,17 @@ export default {
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 11, textSize * 12],
                 headline: { tag: 'xsmall' },
-                disclaimer: 'xsmall'
+                disclaimer: 'xsmall',
+                styles: [textWrap(textSize * 38, textSize, 'US')]
             })
         ],
         [
             'logo.type:primary',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -26,9 +30,13 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
-                    })
+                    }),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
@@ -41,14 +49,15 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3)
+                    altContentMediaQuery(textSize * 34.3),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`],
+                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: false,
                 headline: {
@@ -58,18 +67,22 @@ export default {
         ],
         [
             'logo.type:none',
-            {
+            ({ textSize }) => ({
+                style: [textWrap(textSize * 38, textSize, 'US')],
                 logo: false,
                 messageWidth: false,
                 headline: {
                     br: ['/mo.']
                 }
-            }
+            })
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -77,7 +90,10 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -85,7 +101,8 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     altContentMediaQuery(textSize * 23.8),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_multi_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_gtz.js
@@ -90,7 +90,8 @@ export default {
                 styles: [
                     altContentMediaQuery(textSize * 23.8),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 22, textSize, 'US')
+                    textWrap(textSize * 22, textSize, 'US'),
+                    `.message__headline span:only-child { white-space: normal; }`
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_multi_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_multi_gtz.js
@@ -10,8 +10,7 @@ export default {
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 11, textSize * 12],
                 headline: { tag: 'xsmall' },
-                disclaimer: 'xsmall',
-                styles: []
+                disclaimer: 'xsmall'
             })
         ],
         [
@@ -27,10 +26,7 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     })
                 ]
@@ -62,21 +58,20 @@ export default {
         ],
         [
             'logo.type:none',
-            () => ({
-                style: [],
+            {
                 logo: false,
                 messageWidth: false,
                 headline: {
                     br: ['/mo.']
                 }
-            })
+            }
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 22, textSize, 'US')
                 ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
@@ -87,7 +82,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 22, textSize, 'US')
                 ]
             })
         ],
@@ -97,7 +92,7 @@ export default {
                 styles: [
                     altContentMediaQuery(textSize * 23.8),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 22, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_single_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_single_eqz.js
@@ -14,7 +14,7 @@ export default {
                     br: ['/mo.']
                 },
                 disclaimer: 'xsmall',
-                styles: [textWrap(textSize * 38, textSize, 'US')]
+                styles: []
             })
         ],
         [
@@ -34,18 +34,14 @@ export default {
                     @media (max-width: ${textSize * 17}px) {
                         .message__messaging { display: block; }
                     }
-                    `,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -57,15 +53,14 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 37),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 37)
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
+                styles: [`.message__logo { width: ${textSize * 7}px }`],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: {
@@ -76,8 +71,8 @@ export default {
         ],
         [
             'logo.type:none',
-            ({ textSize }) => ({
-                styles: [textWrap(textSize * 38, textSize, 'US')],
+            () => ({
+                styles: [],
                 messageWidth: false,
                 logo: false,
                 headline: {

--- a/server/locale/US/PPC/mutations/pala_single_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_single_eqz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 export default {
@@ -13,7 +13,8 @@ export default {
                     tag: 'small',
                     br: ['/mo.']
                 },
-                disclaimer: 'xsmall'
+                disclaimer: 'xsmall',
+                styles: [textWrap(textSize * 38, textSize, 'US')]
             })
         ],
         [
@@ -23,21 +24,28 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
                     @media (max-width: ${textSize * 17}px) {
                         .message__messaging { display: block; }
                     }
-                    `
+                    `,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -49,14 +57,15 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 37)
+                    altContentMediaQuery(textSize * 37),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`],
+                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 headline: {
@@ -67,19 +76,23 @@ export default {
         ],
         [
             'logo.type:none',
-            {
+            ({ textSize }) => ({
+                styles: [textWrap(textSize * 38, textSize, 'US')],
                 messageWidth: false,
                 logo: false,
                 headline: {
                     replace: [['APR.', 'APR']],
                     br: ['APR']
                 }
-            }
+            })
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 messageWidth: [textSize * 10, 1000]
             })
@@ -87,7 +100,10 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -95,7 +111,8 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     altContentMediaQuery(textSize * 34.3),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_single_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_single_eqz.js
@@ -90,10 +90,7 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 33, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
             })
         ],
         [

--- a/server/locale/US/PPC/mutations/pala_single_eqz.js
+++ b/server/locale/US/PPC/mutations/pala_single_eqz.js
@@ -13,8 +13,7 @@ export default {
                     tag: 'small',
                     br: ['/mo.']
                 },
-                disclaimer: 'xsmall',
-                styles: []
+                disclaimer: 'xsmall'
             })
         ],
         [
@@ -24,10 +23,7 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
@@ -71,22 +67,21 @@ export default {
         ],
         [
             'logo.type:none',
-            () => ({
-                styles: [],
+            {
                 messageWidth: false,
                 logo: false,
                 headline: {
                     replace: [['APR.', 'APR']],
                     br: ['APR']
                 }
-            })
+            }
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR,
                 messageWidth: [textSize * 10, 1000]
@@ -97,7 +92,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ]
             })
         ],
@@ -107,7 +102,7 @@ export default {
                 styles: [
                     altContentMediaQuery(textSize * 34.3),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 33, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_single_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_single_gtz.js
@@ -7,7 +7,7 @@ export default {
         [
             'default',
             ({ textSize }) => ({
-                styles: [textWrap(textSize * 38, textSize, 'US')],
+                styles: [],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 13, textSize * 18],
                 headline: { tag: 'small', br: ['/mo.'] },
@@ -31,18 +31,14 @@ export default {
                     @media (max-width: ${textSize * 13}px) {
                         .message__messaging { display: block; }
                     }
-                    `,
-                    textWrap(textSize * 38, textSize, 'US')
+                    `
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 9}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
             })
         ],
         [
@@ -54,15 +50,14 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3),
-                    textWrap(textSize * 38, textSize, 'US')
+                    altContentMediaQuery(textSize * 34.3)
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
+                styles: [`.message__logo { width: ${textSize * 7}px }`],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: [textSize * 19, 1000]
             })
@@ -72,7 +67,7 @@ export default {
             ({ textSize }) => ({
                 logo: false,
                 messageWidth: [textSize * 17, 1000],
-                styles: [textWrap(textSize * 38, textSize, 'US')]
+                styles: []
             })
         ],
         [

--- a/server/locale/US/PPC/mutations/pala_single_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_single_gtz.js
@@ -1,5 +1,5 @@
 import Logo from '../logos';
-import { altContentMediaQuery, primaryContentMediaQuery } from './mediaQueries';
+import { altContentMediaQuery, primaryContentMediaQuery, textWrap } from './mediaQueries';
 import { textLogoMutations, flexLogoMutations } from './common';
 
 export default {
@@ -7,6 +7,7 @@ export default {
         [
             'default',
             ({ textSize }) => ({
+                styles: [textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 13, textSize * 18],
                 headline: { tag: 'small', br: ['/mo.'] },
@@ -20,21 +21,28 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
+                        width: {
+                            smallLogo: textSize * 5,
+                            largeLogo: textSize * 9
+                        },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
                     @media (max-width: ${textSize * 13}px) {
                         .message__messaging { display: block; }
                     }
-                    `
+                    `,
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:primary && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 9}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 9}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -46,14 +54,15 @@ export default {
                     .message__logo-container { width: ${textSize * 9}px }
                     .message__content { display: inline-block; }
                     `,
-                    altContentMediaQuery(textSize * 34.3)
+                    altContentMediaQuery(textSize * 34.3),
+                    textWrap(textSize * 38, textSize, 'US')
                 ]
             })
         ],
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [`.message__logo { width: ${textSize * 7}px }`],
+                styles: [`.message__logo { width: ${textSize * 7}px }`, textWrap(textSize * 38, textSize, 'US')],
                 logo: Logo.SINGLE_LINE_NO_PP.COLOR,
                 messageWidth: [textSize * 19, 1000]
             })
@@ -62,13 +71,17 @@ export default {
             'logo.type:none',
             ({ textSize }) => ({
                 logo: false,
-                messageWidth: [textSize * 17, 1000]
+                messageWidth: [textSize * 17, 1000],
+                styles: [textWrap(textSize * 38, textSize, 'US')]
             })
         ],
         [
             'logo.type:alternative',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`],
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })
@@ -76,7 +89,10 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
+                styles: [
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
+                ]
             })
         ],
         [
@@ -84,7 +100,8 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     altContentMediaQuery(textSize * 29.3),
-                    `.message__logo-container { width: ${textSize * 5}px }`
+                    `.message__logo-container { width: ${textSize * 5}px }`,
+                    textWrap(textSize * 38, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_single_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_single_gtz.js
@@ -7,7 +7,6 @@ export default {
         [
             'default',
             ({ textSize }) => ({
-                styles: [],
                 logo: Logo.SINGLE_LINE.COLOR,
                 messageWidth: [textSize * 13, textSize * 18],
                 headline: { tag: 'small', br: ['/mo.'] },
@@ -21,10 +20,7 @@ export default {
                 styles: [
                     primaryContentMediaQuery({
                         logoContainerBP: textSize * 21,
-                        width: {
-                            smallLogo: textSize * 5,
-                            largeLogo: textSize * 9
-                        },
+                        width: { smallLogo: textSize * 5, largeLogo: textSize * 9 },
                         whiteSpaceBP: textSize * 27
                     }),
                     `
@@ -66,8 +62,7 @@ export default {
             'logo.type:none',
             ({ textSize }) => ({
                 logo: false,
-                messageWidth: [textSize * 17, 1000],
-                styles: []
+                messageWidth: [textSize * 17, 1000]
             })
         ],
         [
@@ -75,7 +70,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ],
                 messageWidth: false,
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
@@ -86,7 +81,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ]
             })
         ],
@@ -96,7 +91,7 @@ export default {
                 styles: [
                     altContentMediaQuery(textSize * 29.3),
                     `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 38, textSize, 'US')
+                    textWrap(textSize * 28, textSize, 'US')
                 ],
                 logo: Logo.SINGLE_LINE_NO_PAYPAL.COLOR
             })

--- a/server/locale/US/PPC/mutations/pala_single_gtz.js
+++ b/server/locale/US/PPC/mutations/pala_single_gtz.js
@@ -79,10 +79,7 @@ export default {
         [
             'logo.type:alternative && logo.position:top',
             ({ textSize }) => ({
-                styles: [
-                    `.message__logo-container { width: ${textSize * 5}px }`,
-                    textWrap(textSize * 28, textSize, 'US')
-                ]
+                styles: [`.message__logo-container { width: ${textSize * 5}px }`]
             })
         ],
         [


### PR DESCRIPTION
Change PPC text messages to be on the same line as the logo, and wrap to a newline when there is not enough space