### PR TITLE
feat: Add fontFamily and fontSrc

### DIFF
--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -9,7 +9,7 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -18,10 +18,8 @@ export default {
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
         preset: [Types.STRING, [undefined, 'smallest']],
         text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         }
     }
 };

--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -16,6 +16,12 @@ export default {
     flex: {
         color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey']],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     }
 };

--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -8,7 +8,8 @@ export default {
         text: {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING]
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },

--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -9,7 +9,7 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -21,7 +21,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     }
 };

--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -9,7 +9,7 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -21,7 +21,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     }
 };

--- a/server/locale/DE/validOptions.js
+++ b/server/locale/DE/validOptions.js
@@ -9,7 +9,7 @@ export default {
             color: [Types.STRING, ['black', 'white']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -21,7 +21,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -19,10 +19,8 @@ export default {
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
         preset: [Types.STRING, [undefined, 'smallest']],
         text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         }
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -22,7 +22,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -9,7 +9,8 @@ export default {
         text: {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING]
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -22,7 +22,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -17,6 +17,12 @@ export default {
     flex: {
         color: [Types.STRING, ['blue', 'black', 'white', 'gray|grey', 'monochrome', 'grayscale|greyscale']],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     }
 };

--- a/server/locale/GB/validOptions.js
+++ b/server/locale/GB/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -22,7 +22,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     }
 };

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     }
 };

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -9,7 +9,8 @@ export default {
         text: {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING]
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -20,11 +20,23 @@ export default {
             ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
         ],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     },
     custom: {
         markup: [Types.STRING],
         ratio: [Types.ANY],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     }
 };

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     }
 };

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -22,21 +22,13 @@ export default {
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
         preset: [Types.STRING, [undefined, 'smallest']],
         text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         }
     },
     custom: {
         markup: [Types.STRING],
         ratio: [Types.ANY],
-        preset: [Types.STRING, [undefined, 'smallest']],
-        text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
-        }
+        preset: [Types.STRING, [undefined, 'smallest']]
     }
 };

--- a/server/locale/US/GPL/validOptions.js
+++ b/server/locale/US/GPL/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     }
 };

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSource: [Types.STRING]
         }
     }
 };

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -9,7 +9,8 @@ export default {
         text: {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING]
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -20,11 +20,23 @@ export default {
             ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
         ],
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     },
     custom: {
         markup: [Types.STRING],
         ratio: [Types.ANY],
-        preset: [Types.STRING, [undefined, 'smallest']]
+        preset: [Types.STRING, [undefined, 'smallest']],
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            fontFamily: [Types.STRING],
+            fontSrc: [Types.STRING]
+        }
     }
 };

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.STRING]
+            fontSrc: [Types.MULTI_STRING]
         }
     }
 };

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -22,21 +22,13 @@ export default {
         ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
         preset: [Types.STRING, [undefined, 'smallest']],
         text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
+            fontSource: [Types.ANY]
         }
     },
     custom: {
         markup: [Types.STRING],
         ratio: [Types.ANY],
-        preset: [Types.STRING, [undefined, 'smallest']],
-        text: {
-            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
-            fontFamily: [Types.STRING],
-            fontSource: [Types.STRING]
-        }
+        preset: [Types.STRING, [undefined, 'smallest']]
     }
 };

--- a/server/locale/US/PPC/validOptions.js
+++ b/server/locale/US/PPC/validOptions.js
@@ -10,7 +10,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         },
         preset: [Types.STRING, [undefined, 'smallest']]
     },
@@ -25,7 +25,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             // size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     },
     custom: {
@@ -36,7 +36,7 @@ export default {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
             size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             fontFamily: [Types.STRING],
-            fontSrc: [Types.MULTI_STRING]
+            fontSrc: [Types.STRING]
         }
     }
 };

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -44,8 +44,6 @@ const getfontSourceRule = (addLog, val) => {
     if (!val) {
         return '';
     }
-    /* eslint-disable-next-line security/detect-unsafe-regex */
-    const urlPattern = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
     const fontFormats = {
         woff: 'woff', // woff
         woff2: 'woff2', // woff2
@@ -54,6 +52,7 @@ const getfontSourceRule = (addLog, val) => {
         eot: 'eot', // embedded opentype
         svg: 'svg' // svg
     };
+    const urlPattern = RegExp(`^(?<url>https?://.+?.(?<ext>${[...Object.values(fontFormats)].join('|')}))$`);
     const payload = {
         fontSource: val,
         validValues: [],

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -51,6 +51,7 @@ const getFontSrcRule = val => {
         const fontSrc = JSON.parse(Buffer.from(val, 'base64').toString('ascii'));
         // const fontSrc = JSON.parse(atob(val));
         const ruleVal = (fontSrc?.constructor === Array ? fontSrc : [fontSrc])
+            .slice(0, 10)
             .filter(e => typeof e === 'string')
             .map(url => {
                 const match = urlPat.exec(url);

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -64,26 +64,28 @@ export default ({ options, markup, locale }) => {
     const mutationStyleRules = mutationRules.styles ?? [];
     const customFontStyleRules = [];
     const miscStyleRules = [];
-    const textSize = style.text?.size;
-    const fontFamily = style.text?.fontFamily;
+    const textSize = layout === 'flex' ? undefined : style.text?.size;
     const fontSrc = style.text?.fontSrc;
+    const fontFamily = fontSrc ? 'MerchantCustomFont' : style.text?.fontFamily;
+    const fontSelector = `
+.message__messaging, 
+.message__messaging .message__headline span, 
+.message__messaging .message__disclaimer span`;
+    const textSizeRule = textSize ? `font-size: ${textSize}px; ` : '';
+    const fontFamilyRule = fontFamily ? `font-family: '${fontFamily}'; ` : '';
+
     if (layout === 'text' && textSize) {
-        // miscStyleRules.push(`.message__headline { font-size: ${textSize}px; }`);
-        // miscStyleRules.push(`.message__disclaimer { font-size: ${textSize}px; }`);
         miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
     }
     if (fontSrc) {
         customFontStyleRules.push(`
             @font-face {
-                font-family: 'MerchantCustomFont'; 
+                font-family: '${fontFamily}'; 
                 src: url(${fontSrc});
             }`);
-        customFontStyleRules.push(`
-            .message__messaging { 
-                font-family: 'MerchantCustomFont'; 
-            }`);
-    } else if (fontFamily) {
-        customFontStyleRules.push(`.message__messaging { font-family: '${fontFamily}'; }`);
+    }
+    if (fontFamilyRule || textSizeRule) {
+        customFontStyleRules.push(`${fontSelector}{ ${fontFamilyRule}${textSizeRule} }`);
     }
 
     // Set boundaries on the width of the message text to ensure proper line counts

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -36,38 +36,9 @@ const applyCascade = curry((style, flattened, type, rules) =>
         type === Array ? [] : {}
     )
 );
-// const getFontSrcRule = fontSrc => {
-//     const urlPat = toString(/^(?<url>https?:\/\/.+\.(?<ext>woff|woff2|otf|tff))$/);
-//     const fontFormats = {
-//         woff: 'woff', // woff
-//         // woff2: 'woff2', // woff2
-//         ttf: 'ttf', // truetype
-//         otf: 'otf' // opentype
-//         // eot: 'eot', // embedded opentype
-//         // svg: 'svg' // svg
-//     };
-//     if (fontSrc.constructor === Array) {
-//         const ruleVal = fontSrc
-//             .map(i => {
-//                 // const { url, ext } = urlPat.exec(i)?.groups ?? {};
-//                 const match = urlPat.exec(i);
-//                 // const [matchAll, url, ext, ...rest] = match ?? [];
-//                 const url = match ? match[1] : null;
-//                 const ext = match ? match[2] : null;
-//                 const fmt = fontFormats[ext];
-//                 if (url && fmt) {
-//                     return `url('${url}') format('${fmt}')`;
-//                 }
-//                 return '';
-//             })
-//             .filter(e => e)
-//             .join(', ');
-//         // .trim();
-//         return ruleVal ? `src: ${ruleVal};` : '';
-//     }
-//     return '';
-// };
 const getFontSrcRule = fontSrc => {
+    /* eslint-disable-next-line security/detect-unsafe-regex */
+    const urlPat = RegExp(/\.(?<ext>woff|woff2|otf|tff)$/);
     const fontFormats = {
         woff: 'woff', // woff
         // woff2: 'woff2', // woff2
@@ -78,9 +49,12 @@ const getFontSrcRule = fontSrc => {
     };
     if (fontSrc?.constructor === Array) {
         const ruleVal = fontSrc
-            .map(url => {
-                const sections = url?.split('.') ?? [];
-                const ext = sections.slice(-1)[0];
+            .map(i => {
+                // const { url, ext } = urlPat.exec(i)?.groups ?? {};
+                const match = urlPat.exec(i);
+                // const [matchAll, url, ext, ...rest] = match ?? [];
+                const url = i;
+                const ext = match ? match[2] : null;
                 const fmt = fontFormats[ext];
                 if (url && fmt) {
                     return `url('${url}') format('${fmt}')`;
@@ -88,12 +62,38 @@ const getFontSrcRule = fontSrc => {
                 return '';
             })
             .filter(e => e)
-            .join(', ')
-            .trim();
+            .join(', ');
         return ruleVal ? `src: ${ruleVal};` : '';
     }
     return '';
 };
+// const getFontSrcRule = fontSrc => {
+//     const fontFormats = {
+//         woff: 'woff', // woff
+//         // woff2: 'woff2', // woff2
+//         ttf: 'ttf', // truetype
+//         otf: 'otf' // opentype
+//         // eot: 'eot', // embedded opentype
+//         // svg: 'svg' // svg
+//     };
+//     if (fontSrc?.constructor === Array) {
+//         const ruleVal = fontSrc
+//             .map(url => {
+//                 const sections = url?.split('.') ?? [];
+//                 const ext = sections.slice(-1)[0];
+//                 const fmt = fontFormats[ext];
+//                 if (url && fmt) {
+//                     return `url('${url}') format('${fmt}')`;
+//                 }
+//                 return '';
+//             })
+//             .filter(e => e)
+//             .join(', ')
+//             .trim();
+//         return ruleVal ? `src: ${ruleVal};` : '';
+//     }
+//     return '';
+// };
 export default ({ options, markup, locale }) => {
     const offerType = markup?.meta?.offerType;
     const style =

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -36,7 +36,7 @@ const applyCascade = curry((style, flattened, type, rules) =>
         type === Array ? [] : {}
     )
 );
-const getFontSrcRule = val => {
+const getfontSourceRule = val => {
     /* eslint-disable-next-line security/detect-unsafe-regex */
     const urlPat = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
     const fontFormats = {
@@ -48,9 +48,9 @@ const getFontSrcRule = val => {
         // svg: 'svg' // svg
     };
     try {
-        const fontSrc = JSON.parse(Buffer.from(val, 'base64').toString('ascii'));
-        // const fontSrc = JSON.parse(atob(val));
-        const ruleVal = (fontSrc?.constructor === Array ? fontSrc : [fontSrc])
+        const fontSource = JSON.parse(Buffer.from(val, 'base64').toString('ascii'));
+        // const fontSource = JSON.parse(atob(val));
+        const ruleVal = (fontSource?.constructor === Array ? fontSource : [fontSource])
             .slice(0, 10)
             .filter(e => typeof e === 'string')
             .map(url => {
@@ -70,7 +70,27 @@ const getFontSrcRule = val => {
         return '';
     }
 };
-
+const getFontFamilyRule = val => {
+    const genericFamilies = {
+        serif: 'serif',
+        'sans-serif': 'sans-serif',
+        monospace: 'monospace',
+        cursive: 'cursive',
+        fantasy: 'fantasy',
+        'system-ui': 'system-ui',
+        'ui-serif': 'ui-serif',
+        'ui-sans-serif': 'ui-sans-serif',
+        'ui-monospace': 'ui-monospace',
+        math: 'math',
+        emoji: 'emoji',
+        fangsong: 'fangsong'
+    };
+    const fontFamily = typeof val === 'string' ? genericFamilies[val] ?? `'${val}'` : '';
+    if (fontFamily) {
+        return `font-family: ${fontFamily}, PayPal-Sans-Big, PayPal-Sans, Arial, sans-serif; `;
+    }
+    return '';
+};
 export default ({ options, markup, locale }) => {
     const offerType = markup?.meta?.offerType;
     const style =
@@ -99,27 +119,22 @@ export default ({ options, markup, locale }) => {
     const customFontStyleRules = [];
     const miscStyleRules = [];
     const textSize = layout === 'flex' ? undefined : style.text?.size;
-    const fontSrc = style.text?.fontSrc;
-    const fontFamily = fontSrc ? 'MerchantCustomFont' : style.text?.fontFamily;
+    const fontSource = style.text?.fontSource;
+    const fontFamily = fontSource ? 'MerchantCustomFont' : style.text?.fontFamily;
     const fontSelector = `
 .message__messaging, 
 .message__messaging .message__headline span, 
 .message__messaging .message__disclaimer span`;
     const textSizeRule = textSize ? `font-size: ${textSize}px; ` : '';
-    const fontFamilyRule = fontFamily
-        ? `font-family: '${fontFamily}', PayPal-Sans-Big, PayPal-Sans, Arial, sans-serif; `
-        : '';
-    const fontSrcRule = getFontSrcRule(fontSrc);
+
+    const fontFamilyRule = getFontFamilyRule(fontFamily);
+    const fontSourceRule = getfontSourceRule(fontSource);
 
     if (layout === 'text' && textSize) {
         miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
     }
-    if (fontSrc) {
-        customFontStyleRules.push(`
-            @font-face {
-                font-family: '${fontFamily}'; 
-                ${fontSrcRule}
-            }`);
+    if (fontSource) {
+        customFontStyleRules.push(`@font-face {font-family: '${fontFamily}'; ${fontSourceRule}}`);
     }
     if (fontFamilyRule || textSizeRule) {
         customFontStyleRules.push(`${fontSelector}{ ${fontFamilyRule}${textSizeRule} }`);

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -62,13 +62,28 @@ export default ({ options, markup, locale }) => {
         rule.replace(/\.message/g, `.${localeClass} .message`)
     );
     const mutationStyleRules = mutationRules.styles ?? [];
+    const customFontStyleRules = [];
     const miscStyleRules = [];
-
     const textSize = style.text?.size;
+    const fontFamily = style.text?.fontFamily;
+    const fontSrc = style.text?.fontSrc;
     if (layout === 'text' && textSize) {
         // miscStyleRules.push(`.message__headline { font-size: ${textSize}px; }`);
         // miscStyleRules.push(`.message__disclaimer { font-size: ${textSize}px; }`);
         miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
+    }
+    if (fontSrc) {
+        customFontStyleRules.push(`
+            @font-face {
+                font-family: 'MerchantCustomFont'; 
+                src: url(${fontSrc});
+            }`);
+        customFontStyleRules.push(`
+            .message__messaging { 
+                font-family: 'MerchantCustomFont'; 
+            }`);
+    } else if (fontFamily) {
+        customFontStyleRules.push(`.message__messaging { font-family: '${fontFamily}'; }`);
     }
 
     // Set boundaries on the width of the message text to ensure proper line counts
@@ -103,6 +118,7 @@ export default ({ options, markup, locale }) => {
                     localeStyleRules={localeStyleRules}
                     mutationStyleRules={mutationStyleRules}
                     miscStyleRules={miscStyleRules}
+                    customFontStyleRules={customFontStyleRules}
                 />
             </CustomMessage>
         );
@@ -115,6 +131,7 @@ export default ({ options, markup, locale }) => {
                 localeStyleRules={localeStyleRules}
                 mutationStyleRules={mutationStyleRules}
                 miscStyleRules={miscStyleRules}
+                customFontStyleRules={customFontStyleRules}
             />
             <div className={`message__container ${localeClass}`}>
                 {/* foreground layer */}

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -38,7 +38,7 @@ const applyCascade = curry((style, flattened, type, rules) =>
 );
 const getFontSrcRule = fontSrc => {
     /* eslint-disable-next-line security/detect-unsafe-regex */
-    const urlPat = RegExp(/\.(?<ext>woff|woff2|otf|tff)$/);
+    const urlPat = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
     const fontFormats = {
         woff: 'woff', // woff
         // woff2: 'woff2', // woff2
@@ -49,11 +49,8 @@ const getFontSrcRule = fontSrc => {
     };
     if (fontSrc?.constructor === Array) {
         const ruleVal = fontSrc
-            .map(i => {
-                // const { url, ext } = urlPat.exec(i)?.groups ?? {};
-                const match = urlPat.exec(i);
-                // const [matchAll, url, ext, ...rest] = match ?? [];
-                const url = i;
+            .map(url => {
+                const match = urlPat.exec(url);
                 const ext = match ? match[2] : null;
                 const fmt = fontFormats[ext];
                 if (url && fmt) {
@@ -67,33 +64,7 @@ const getFontSrcRule = fontSrc => {
     }
     return '';
 };
-// const getFontSrcRule = fontSrc => {
-//     const fontFormats = {
-//         woff: 'woff', // woff
-//         // woff2: 'woff2', // woff2
-//         ttf: 'ttf', // truetype
-//         otf: 'otf' // opentype
-//         // eot: 'eot', // embedded opentype
-//         // svg: 'svg' // svg
-//     };
-//     if (fontSrc?.constructor === Array) {
-//         const ruleVal = fontSrc
-//             .map(url => {
-//                 const sections = url?.split('.') ?? [];
-//                 const ext = sections.slice(-1)[0];
-//                 const fmt = fontFormats[ext];
-//                 if (url && fmt) {
-//                     return `url('${url}') format('${fmt}')`;
-//                 }
-//                 return '';
-//             })
-//             .filter(e => e)
-//             .join(', ')
-//             .trim();
-//         return ruleVal ? `src: ${ruleVal};` : '';
-//     }
-//     return '';
-// };
+
 export default ({ options, markup, locale }) => {
     const offerType = markup?.meta?.offerType;
     const style =

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -50,9 +50,9 @@ const getfontSourceRule = (addLog, val) => {
         woff: 'woff', // woff
         woff2: 'woff2', // woff2
         ttf: 'ttf', // truetype
-        otf: 'otf' // opentype
-        // eot: 'eot', // embedded opentype
-        // svg: 'svg' // svg
+        otf: 'otf', // opentype
+        eot: 'eot', // embedded opentype
+        svg: 'svg' // svg
     };
     const payload = {
         fontSource: val,

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -52,7 +52,7 @@ const getfontSourceRule = (addLog, fontSource) => {
         eot: 'eot', // embedded opentype
         svg: 'svg' // svg
     };
-    const urlPattern = RegExp(`^(?<url>https?://.+?.(?<ext>${[...Object.values(fontFormats)].join('|')}))$`);
+    const urlPattern = RegExp(`^(https?://.+?.(${[...Object.values(fontFormats)].join('|')}))$`);
     const payload = {
         fontSource,
         validValues: []
@@ -87,6 +87,7 @@ const getFontFamilyRule = (addLog, val) => {
         validValue: null
     };
     const genericFamilies = {
+        // using a generic family requires the value not be quoted
         serif: 'serif',
         'sans-serif': 'sans-serif',
         monospace: 'monospace',
@@ -159,10 +160,6 @@ export default ({ addLog, options, markup, locale }) => {
     const mutationStyleRules = mutationRules.styles ?? [];
     const customFontStyleRules = getFontRules(addLog, style);
     const miscStyleRules = [];
-
-    // if (layout === 'text' && textSize) {
-    //     miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
-    // }
 
     // Set boundaries on the width of the message text to ensure proper line counts
     if (mutationRules.messageWidth) {

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -119,6 +119,31 @@ const getFontFamilyRule = (addLog, val) => {
     logInfo(addLog, payload);
     return '';
 };
+const getFontRules = (addLog, style) => {
+    const rules = [];
+    const textSize = style.layout === 'flex' ? undefined : style?.text?.size;
+    const fontSource = style?.text?.fontSource;
+    const fontFamily = fontSource ? 'MerchantCustomFont' : style?.text?.fontFamily;
+
+    const fontSelector = [
+        '.message__messaging', // text layout
+        '.message__messaging .message__headline span', // flex layout
+        '.message__messaging .message__sub-headline span',
+        '.message__messaging .message__disclaimer span'
+    ].join(',\n');
+
+    const textSizeRule = Number.isNaN(textSize) ? '' : `font-size: ${textSize}px; `;
+    const fontFamilyRule = getFontFamilyRule(addLog, fontFamily);
+    const fontSourceRule = getfontSourceRule(addLog, fontSource);
+
+    if (fontSource) {
+        rules.push(`@font-face {font-family: '${fontFamily}'; ${fontSourceRule}}`);
+    }
+    if (fontFamilyRule || textSizeRule) {
+        rules.push(`${fontSelector}{ ${fontFamilyRule}${textSizeRule} }`);
+    }
+    return rules;
+};
 export default ({ addLog, options, markup, locale }) => {
     const offerType = markup?.meta?.offerType;
     const style =
@@ -144,29 +169,12 @@ export default ({ addLog, options, markup, locale }) => {
         rule.replace(/\.message/g, `.${localeClass} .message`)
     );
     const mutationStyleRules = mutationRules.styles ?? [];
-    const customFontStyleRules = [];
+    const customFontStyleRules = getFontRules(addLog, style);
     const miscStyleRules = [];
-    const textSize = layout === 'flex' ? undefined : style.text?.size;
-    const fontSource = style.text?.fontSource;
-    const fontFamily = fontSource ? 'MerchantCustomFont' : style.text?.fontFamily;
-    const fontSelector = `
-.message__messaging, 
-.message__messaging .message__headline span, 
-.message__messaging .message__sub-headline span, 
-.message__messaging .message__disclaimer span`;
-    const textSizeRule = Number.isNaN(textSize) ? '' : `font-size: ${textSize}px; `;
-    const fontFamilyRule = getFontFamilyRule(addLog, fontFamily);
-    const fontSourceRule = getfontSourceRule(addLog, fontSource);
 
     // if (layout === 'text' && textSize) {
     //     miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
     // }
-    if (fontSource) {
-        customFontStyleRules.push(`@font-face {font-family: '${fontFamily}'; ${fontSourceRule}}`);
-    }
-    if (fontFamilyRule || textSizeRule) {
-        customFontStyleRules.push(`${fontSelector}{ ${fontFamilyRule}${textSizeRule} }`);
-    }
 
     // Set boundaries on the width of the message text to ensure proper line counts
     if (mutationRules.messageWidth) {

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -36,7 +36,64 @@ const applyCascade = curry((style, flattened, type, rules) =>
         type === Array ? [] : {}
     )
 );
-
+// const getFontSrcRule = fontSrc => {
+//     const urlPat = toString(/^(?<url>https?:\/\/.+\.(?<ext>woff|woff2|otf|tff))$/);
+//     const fontFormats = {
+//         woff: 'woff', // woff
+//         // woff2: 'woff2', // woff2
+//         ttf: 'ttf', // truetype
+//         otf: 'otf' // opentype
+//         // eot: 'eot', // embedded opentype
+//         // svg: 'svg' // svg
+//     };
+//     if (fontSrc.constructor === Array) {
+//         const ruleVal = fontSrc
+//             .map(i => {
+//                 // const { url, ext } = urlPat.exec(i)?.groups ?? {};
+//                 const match = urlPat.exec(i);
+//                 // const [matchAll, url, ext, ...rest] = match ?? [];
+//                 const url = match ? match[1] : null;
+//                 const ext = match ? match[2] : null;
+//                 const fmt = fontFormats[ext];
+//                 if (url && fmt) {
+//                     return `url('${url}') format('${fmt}')`;
+//                 }
+//                 return '';
+//             })
+//             .filter(e => e)
+//             .join(', ');
+//         // .trim();
+//         return ruleVal ? `src: ${ruleVal};` : '';
+//     }
+//     return '';
+// };
+const getFontSrcRule = fontSrc => {
+    const fontFormats = {
+        woff: 'woff', // woff
+        // woff2: 'woff2', // woff2
+        ttf: 'ttf', // truetype
+        otf: 'otf' // opentype
+        // eot: 'eot', // embedded opentype
+        // svg: 'svg' // svg
+    };
+    if (fontSrc?.constructor === Array) {
+        const ruleVal = fontSrc
+            .map(url => {
+                const sections = url?.split('.') ?? [];
+                const ext = sections.slice(-1)[0];
+                const fmt = fontFormats[ext];
+                if (url && fmt) {
+                    return `url('${url}') format('${fmt}')`;
+                }
+                return '';
+            })
+            .filter(e => e)
+            .join(', ')
+            .trim();
+        return ruleVal ? `src: ${ruleVal};` : '';
+    }
+    return '';
+};
 export default ({ options, markup, locale }) => {
     const offerType = markup?.meta?.offerType;
     const style =
@@ -72,7 +129,10 @@ export default ({ options, markup, locale }) => {
 .message__messaging .message__headline span, 
 .message__messaging .message__disclaimer span`;
     const textSizeRule = textSize ? `font-size: ${textSize}px; ` : '';
-    const fontFamilyRule = fontFamily ? `font-family: '${fontFamily}'; ` : '';
+    const fontFamilyRule = fontFamily
+        ? `font-family: '${fontFamily}', PayPal-Sans-Big, PayPal-Sans, Arial, sans-serif; `
+        : '';
+    const fontSrcRule = getFontSrcRule(fontSrc);
 
     if (layout === 'text' && textSize) {
         miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
@@ -81,12 +141,18 @@ export default ({ options, markup, locale }) => {
         customFontStyleRules.push(`
             @font-face {
                 font-family: '${fontFamily}'; 
-                src: url(${fontSrc});
+                ${fontSrcRule}
             }`);
     }
     if (fontFamilyRule || textSizeRule) {
         customFontStyleRules.push(`${fontSelector}{ ${fontFamilyRule}${textSizeRule} }`);
     }
+    // const textSize = style.text?.size;
+    // if (layout === 'text' && textSize) {
+    //     // miscStyleRules.push(`.message__headline { font-size: ${textSize}px; }`);
+    //     // miscStyleRules.push(`.message__disclaimer { font-size: ${textSize}px; }`);
+    //     miscStyleRules.push(`.message__messaging { font-size: ${textSize}px; }`);
+    // }
 
     // Set boundaries on the width of the message text to ensure proper line counts
     if (mutationRules.messageWidth) {

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -153,8 +153,9 @@ export default ({ addLog, options, markup, locale }) => {
     const fontSelector = `
 .message__messaging, 
 .message__messaging .message__headline span, 
+.message__messaging .message__sub-headline span, 
 .message__messaging .message__disclaimer span`;
-    const textSizeRule = textSize ? `font-size: ${textSize}px; ` : '';
+    const textSizeRule = Number.isNaN(textSize) ? '' : `font-size: ${textSize}px; `;
     const fontFamilyRule = getFontFamilyRule(addLog, fontFamily);
     const fontSourceRule = getfontSourceRule(addLog, fontSource);
 

--- a/server/message/index.jsx
+++ b/server/message/index.jsx
@@ -36,7 +36,7 @@ const applyCascade = curry((style, flattened, type, rules) =>
         type === Array ? [] : {}
     )
 );
-const getFontSrcRule = fontSrc => {
+const getFontSrcRule = val => {
     /* eslint-disable-next-line security/detect-unsafe-regex */
     const urlPat = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
     const fontFormats = {
@@ -47,8 +47,11 @@ const getFontSrcRule = fontSrc => {
         // eot: 'eot', // embedded opentype
         // svg: 'svg' // svg
     };
-    if (fontSrc?.constructor === Array) {
-        const ruleVal = fontSrc
+    try {
+        const fontSrc = JSON.parse(Buffer.from(val, 'base64').toString('ascii'));
+        // const fontSrc = JSON.parse(atob(val));
+        const ruleVal = (fontSrc?.constructor === Array ? fontSrc : [fontSrc])
+            .filter(e => typeof e === 'string')
             .map(url => {
                 const match = urlPat.exec(url);
                 const ext = match ? match[2] : null;
@@ -61,8 +64,10 @@ const getFontSrcRule = fontSrc => {
             .filter(e => e)
             .join(', ');
         return ruleVal ? `src: ${ruleVal};` : '';
+    } catch (err) {
+        // TODO: report on failed parameter?
+        return '';
     }
-    return '';
 };
 
 export default ({ options, markup, locale }) => {

--- a/server/message/parts/Styles.jsx
+++ b/server/message/parts/Styles.jsx
@@ -5,7 +5,7 @@ import fonts from '../styles/fonts.css';
 
 // Disabling of react/no-danger is done line by line to ensure the code is intentional. Do not block disable this.
 // Shared mutations, styles, and fonts between custom and non-custom messages/banners.
-const Styles = ({ globalStyleRules, localeStyleRules, mutationStyleRules, miscStyleRules }) => {
+const Styles = ({ globalStyleRules, localeStyleRules, mutationStyleRules, miscStyleRules, customFontStyleRules }) => {
     return (
         <>
             {/* eslint-disable-next-line react/no-danger */}
@@ -18,6 +18,11 @@ const Styles = ({ globalStyleRules, localeStyleRules, mutationStyleRules, miscSt
             <style className="styles__mutations" dangerouslySetInnerHTML={{ __html: mutationStyleRules.join('\n') }} />
             {/* eslint-disable-next-line react/no-danger */}
             <style className="styles__misc" dangerouslySetInnerHTML={{ __html: miscStyleRules.join('\n') }} />
+            <style
+                className="styles__customFont"
+                /* eslint-disable-next-line react/no-danger */
+                dangerouslySetInnerHTML={{ __html: customFontStyleRules.join('\n') }}
+            />
         </>
     );
 };

--- a/server/render.jsx
+++ b/server/render.jsx
@@ -4,6 +4,6 @@ import render from 'preact-render-to-string';
 
 import Message from './message';
 
-export default (options, markup) => {
-    return render(<Message options={options} markup={markup} locale={markup.meta.offerCountry} />);
+export default (addLog, options, markup) => {
+    return render(<Message addLog={addLog} options={options} markup={markup} locale={markup.meta.offerCountry} />);
 };

--- a/server/types.js
+++ b/server/types.js
@@ -3,7 +3,6 @@ export const Types = {
     STRING: 'STRING',
     BOOLEAN: 'BOOLEAN',
     NUMBER: 'NUMBER',
-    MULTI_STRING: 'MULTI_STRING',
     FUNCTION: 'FUNCTION',
     OBJECT: 'OBJECT'
 };
@@ -20,8 +19,6 @@ export function validateType(expectedType, val) {
             return typeof val === 'function';
         case Types.OBJECT:
             return typeof val === 'object' && val !== null;
-        case Types.MULTI_STRING:
-            return validateType('STRING', val) || (typeof val === 'object' && val?.constructor === Array);
         case Types.ANY:
             return true;
         default:

--- a/server/types.js
+++ b/server/types.js
@@ -3,6 +3,7 @@ export const Types = {
     STRING: 'STRING',
     BOOLEAN: 'BOOLEAN',
     NUMBER: 'NUMBER',
+    MULTI_STRING: 'MULTI_STRING',
     FUNCTION: 'FUNCTION',
     OBJECT: 'OBJECT'
 };
@@ -19,6 +20,8 @@ export function validateType(expectedType, val) {
             return typeof val === 'function';
         case Types.OBJECT:
             return typeof val === 'object' && val !== null;
+        case Types.MULTI_STRING:
+            return validateType('STRING', val) || (typeof val === 'object' && val?.constructor === Array);
         case Types.ANY:
             return true;
         default:

--- a/server/validateStyle.js
+++ b/server/validateStyle.js
@@ -42,7 +42,14 @@ function getValidVal(addLog, typeArr, val, location) {
 
             return validVal.split('|')[0];
         }
-
+        if (type === Types.MULTI_STRING) {
+            if (typeof val === 'string') {
+                return [val];
+            }
+            if (val?.constructor === Array) {
+                return val.filter(e => e);
+            }
+        }
         return val;
     }
 

--- a/server/validateStyle.js
+++ b/server/validateStyle.js
@@ -14,6 +14,7 @@ const logInvalidOption = (addLog, location, options, val) =>
             /^[a-z0-9]+$/i.test(val) ? val : 'REDACTED'
         }".`
     );
+
 function getValidVal(addLog, typeArr, val, location) {
     const [type, validVals = []] = typeArr;
 

--- a/server/validateStyle.js
+++ b/server/validateStyle.js
@@ -14,7 +14,38 @@ const logInvalidOption = (addLog, location, options, val) =>
             /^[a-z0-9]+$/i.test(val) ? val : 'REDACTED'
         }".`
     );
-
+function validateFontSrc(fontSrc) {
+    /* eslint-disable-next-line security/detect-unsafe-regex */
+    const urlPat = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
+    const fontFormats = {
+        woff: 'woff', // woff
+        // woff2: 'woff2', // woff2
+        ttf: 'ttf', // truetype
+        otf: 'otf' // opentype
+        // eot: 'eot', // embedded opentype
+        // svg: 'svg' // svg
+    };
+    let result = [];
+    const verifyUrls = fontSrc => {
+        return fontSrc
+            .map(url => {
+                const match = urlPat.exec(url);
+                const ext = match ? match[2] : null;
+                const fmt = fontFormats[ext];
+                if (url && fmt) {
+                    return url;
+                }
+                return '';
+            })
+            .filter(e => e);
+    };
+    if (typeof fontSrc === 'string') {
+        result = verifyUrls([fontSrc]);
+    } else if (fontSrc?.constructor === Array) {
+        result = verifyUrls(fontSrc);
+    }
+    return result;
+}
 function getValidVal(addLog, typeArr, val, location) {
     const [type, validVals = []] = typeArr;
 
@@ -42,11 +73,15 @@ function getValidVal(addLog, typeArr, val, location) {
 
             return validVal.split('|')[0];
         }
+        if (location === 'style.text.fontSrc') {
+            return validateFontSrc(val);
+        }
         if (type === Types.MULTI_STRING) {
             if (typeof val === 'string') {
                 return [val];
             }
             if (val?.constructor === Array) {
+                console.log(val);
                 return val.filter(e => e);
             }
         }

--- a/server/validateStyle.js
+++ b/server/validateStyle.js
@@ -14,38 +14,6 @@ const logInvalidOption = (addLog, location, options, val) =>
             /^[a-z0-9]+$/i.test(val) ? val : 'REDACTED'
         }".`
     );
-function validateFontSrc(fontSrc) {
-    /* eslint-disable-next-line security/detect-unsafe-regex */
-    const urlPat = RegExp(/^(?<url>https?:\/\/.+?\.(?<ext>woff|woff2|otf|tff))$/);
-    const fontFormats = {
-        woff: 'woff', // woff
-        // woff2: 'woff2', // woff2
-        ttf: 'ttf', // truetype
-        otf: 'otf' // opentype
-        // eot: 'eot', // embedded opentype
-        // svg: 'svg' // svg
-    };
-    let result = [];
-    const verifyUrls = fontSrc => {
-        return fontSrc
-            .map(url => {
-                const match = urlPat.exec(url);
-                const ext = match ? match[2] : null;
-                const fmt = fontFormats[ext];
-                if (url && fmt) {
-                    return url;
-                }
-                return '';
-            })
-            .filter(e => e);
-    };
-    if (typeof fontSrc === 'string') {
-        result = verifyUrls([fontSrc]);
-    } else if (fontSrc?.constructor === Array) {
-        result = verifyUrls(fontSrc);
-    }
-    return result;
-}
 function getValidVal(addLog, typeArr, val, location) {
     const [type, validVals = []] = typeArr;
 
@@ -72,18 +40,6 @@ function getValidVal(addLog, typeArr, val, location) {
             }
 
             return validVal.split('|')[0];
-        }
-        if (location === 'style.text.fontSrc') {
-            return validateFontSrc(val);
-        }
-        if (type === Types.MULTI_STRING) {
-            if (typeof val === 'string') {
-                return [val];
-            }
-            if (val?.constructor === Array) {
-                console.log(val);
-                return val.filter(e => e);
-            }
         }
         return val;
     }

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -37,15 +37,31 @@ export function isElement(el) {
 export function getInlineOptions(container) {
     // Allows for data attributes dependent on camel casing to function properly.
     const attributeNameOverride = {
-        'data-pp-buyercountry': 'data-pp-buyerCountry'
+        'data-pp-buyercountry': 'data-pp-buyerCountry',
+        'data-pp-style-text-fontfamily': 'data-pp-style-text-fontFamily',
+        'data-pp-style-text-fontsource': 'data-pp-style-text-fontSource'
     };
-
+    const getOptionValue = (name, value) => {
+        if (name === 'style-text-fontSource' && value?.indexOf('[') >= 0) {
+            try {
+                return flattenedToObject(name, JSON.parse(value));
+            } catch (err) {
+                console.error(err.stack);
+            }
+            try {
+                return flattenedToObject(name, JSON.parse(value.replace(/'/g, '"')));
+            } catch (err) {
+                console.error(err.stack);
+            }
+        }
+        return flattenedToObject(name, value);
+    };
     const dataOptions = arrayFrom(container.attributes)
         .filter(({ nodeName }) => stringStartsWith(nodeName, 'data-pp-'))
         .reduce((accumulator, { nodeName, nodeValue }) => {
             if (nodeValue) {
                 if (attributeNameOverride[nodeName]) nodeName = attributeNameOverride[nodeName]; // eslint-disable-line no-param-reassign
-                return objectMerge(accumulator, flattenedToObject(nodeName.replace('data-pp-', ''), nodeValue));
+                return objectMerge(accumulator, getOptionValue(nodeName.replace('data-pp-', ''), nodeValue));
             }
 
             return accumulator;

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -42,7 +42,7 @@ export function getInlineOptions(container) {
         'data-pp-style-text-fontsource': 'data-pp-style-text-fontSource'
     };
     const getOptionValue = (name, value) => {
-        if (name === 'style-text-fontSource' && stringStartsWith(value, '[')) {
+        if (stringStartsWith(value, '[')) {
             try {
                 return flattenedToObject(name, JSON.parse(value.replace(/'/g, '"')));
             } catch (err) {

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -45,9 +45,7 @@ export function getInlineOptions(container) {
         if (stringStartsWith(value, '[')) {
             try {
                 return flattenedToObject(name, JSON.parse(value.replace(/'/g, '"')));
-            } catch (err) {
-                console.error(err.stack); // eslint-disable-line no-console
-            }
+            } catch (err) {} // eslint-disable-line no-empty
         }
         return flattenedToObject(name, value);
     };

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -42,16 +42,11 @@ export function getInlineOptions(container) {
         'data-pp-style-text-fontsource': 'data-pp-style-text-fontSource'
     };
     const getOptionValue = (name, value) => {
-        if (name === 'style-text-fontSource' && value?.indexOf('[') >= 0) {
-            try {
-                return flattenedToObject(name, JSON.parse(value));
-            } catch (err) {
-                console.error(err.stack);
-            }
+        if (name === 'style-text-fontSource' && stringStartsWith(value, '[')) {
             try {
                 return flattenedToObject(name, JSON.parse(value.replace(/'/g, '"')));
             } catch (err) {
-                console.error(err.stack);
+                console.error(err.stack); // eslint-disable-line no-console
             }
         }
         return flattenedToObject(name, value);

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,6 +103,33 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
+        let fontSrc = style?.text?.fontSrc;
+
+        if (fontSrc) {
+            if (typeof fontSrc === 'string') {
+                fontSrc = [fontSrc];
+            }
+            if (fontSrc?.constructor === Array) {
+                fontSrc.filter(url => {
+                    const fontFormats = {
+                        woff: 'woff', // woff
+                        // woff2: 'woff2', // woff2
+                        ttf: 'ttf', // truetype
+                        otf: 'otf' // opentype
+                        // eot: 'eot', // embedded opentype
+                        // svg: 'svg' // svg
+                    };
+                    const ext = url?.split('.').slice(-1);
+                    return url && url.indexOf('http') === 0 && fontFormats[ext];
+                });
+            }
+            if (fontSrc) {
+                console.log(`fontSrc:`, fontSrc);
+                style.text.fontSrc = fontSrc;
+            } else {
+                delete style.text.fontSrc;
+            }
+        }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {
                 return style;

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,32 +103,12 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
-        let fontSrc = style?.text?.fontSrc;
+        const fontSrc = style?.text?.fontSrc;
 
         if (fontSrc) {
-            if (typeof fontSrc === 'string') {
-                fontSrc = [fontSrc];
-            }
-            if (fontSrc?.constructor === Array) {
-                fontSrc.filter(url => {
-                    const fontFormats = {
-                        woff: 'woff', // woff
-                        // woff2: 'woff2', // woff2
-                        ttf: 'ttf', // truetype
-                        otf: 'otf' // opentype
-                        // eot: 'eot', // embedded opentype
-                        // svg: 'svg' // svg
-                    };
-                    const ext = url?.split('.').slice(-1);
-                    return url && url.indexOf('http') === 0 && fontFormats[ext];
-                });
-            }
-            if (fontSrc) {
-                console.log(`fontSrc:`, fontSrc);
-                style.text.fontSrc = fontSrc;
-            } else {
-                delete style.text.fontSrc;
-            }
+            // style.text.fontSrc = Buffer.from(JSON.stringify(fontSrc)).toString('base64');
+            /* eslint-disable-next-line no-param-reassign */
+            style.text.fontSrc = btoa(JSON.stringify(fontSrc));
         }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,16 +103,21 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
-        const styleOptions = { ...style };
-        const fontSource = styleOptions?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
-
+        const newStyle = { ...style };
+        const fontSource = style?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
+        if (fontSource) {
+            newStyle.text.fontSource = fontSource;
+        }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {
-                return { fontSource, ...style };
+                return newStyle;
             }
 
             if (validateType(Types.STRING, style.preset)) {
-                return { fontSource, layout: 'text', ...style };
+                return {
+                    layout: 'text',
+                    ...newStyle
+                };
             }
         }
 

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,11 +103,6 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
-        // const newStyle = { ...style };
-        // const fontSource = style?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
-        // if (fontSource) {
-        //     newStyle.text.fontSource = fontSource;
-        // }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {
                 return style;

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,20 +103,20 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
-        const newStyle = { ...style };
-        const fontSource = style?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
-        if (fontSource) {
-            newStyle.text.fontSource = fontSource;
-        }
+        // const newStyle = { ...style };
+        // const fontSource = style?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
+        // if (fontSource) {
+        //     newStyle.text.fontSource = fontSource;
+        // }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {
-                return newStyle;
+                return style;
             }
 
             if (validateType(Types.STRING, style.preset)) {
                 return {
                     layout: 'text',
-                    ...newStyle
+                    ...style
                 };
             }
         }

--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -103,20 +103,16 @@ export default {
     // TODO: Handle server side locale specific style validation warnings passed down to client.
     // Likely makes sens to pass down in the onReady callback
     style: ({ props: { style } }) => {
-        const fontSrc = style?.text?.fontSrc;
+        const styleOptions = { ...style };
+        const fontSource = styleOptions?.text?.fontSource ? btoa(JSON.stringify(style.text.fontSource)) : undefined;
 
-        if (fontSrc) {
-            // style.text.fontSrc = Buffer.from(JSON.stringify(fontSrc)).toString('base64');
-            /* eslint-disable-next-line no-param-reassign */
-            style.text.fontSrc = btoa(JSON.stringify(fontSrc));
-        }
         if (validateType(Types.OBJECT, style)) {
             if (validateType(Types.STRING, style.layout)) {
-                return style;
+                return { fontSource, ...style };
             }
 
             if (validateType(Types.STRING, style.preset)) {
-                return { layout: 'text', ...style };
+                return { fontSource, layout: 'text', ...style };
             }
         }
 

--- a/tests/unit/spec/server/message/index.test.js
+++ b/tests/unit/spec/server/message/index.test.js
@@ -4,6 +4,7 @@ import { render } from '@testing-library/preact';
 
 import Message from 'server/message';
 import { getMutations, getLocaleStyles } from 'server/locale';
+import { objectSet } from 'src/utils';
 
 const mockLogger = jest.fn();
 
@@ -40,7 +41,9 @@ jest.mock('server/message/styles/fonts.css', () => ({
 
 jest.mock('server/message/styles', () => ({
     default: {
-        'layout:text': [['default', '']]
+        'layout:text': [['default', '']],
+        'layout:flex': [['default', '']],
+        'layout:custom': [['default', '']]
     },
     __esModule: true
 }));
@@ -90,34 +93,178 @@ describe('SSR message', () => {
 
         getLocaleStyles.mockReturnValue([]);
     });
-
-    test('renders message content', () => {
-        const logoSrc = 'logoSrc';
-
-        getMutations.mockReturnValue(
-            defaultMutations({
-                subHeadline: 'default',
-                disclaimer: 'default',
+    describe('renders message', () => {
+        const renderOptions = {
+            style: {
+                layout: 'text',
                 logo: {
-                    src: logoSrc,
-                    dimensions: [10, 10]
+                    type: 'primary',
+                    position: 'left'
+                },
+                text: {
+                    size: 12
                 }
-            })
-        );
+            }
+        };
+        test('content', () => {
+            const logoSrc = 'logoSrc';
 
-        const { getByText, getByAltText, container } = render(
-            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
-        );
+            getMutations.mockReturnValue(
+                defaultMutations({
+                    subHeadline: 'default',
+                    disclaimer: 'default',
+                    logo: {
+                        src: logoSrc,
+                        dimensions: [10, 10]
+                    }
+                })
+            );
+            const { getByText, getByAltText } = render(
+                <Message locale="US" addLog={mockLogger} options={renderOptions} markup={defaultMarkup()} />
+            );
+            expect(getByText(headline)).toBeInTheDocument();
+            expect(getByText(subHeadline)).toBeInTheDocument();
+            expect(getByText(disclaimer)).toBeInTheDocument();
 
-        expect(getByText(headline)).toBeInTheDocument();
-        expect(getByText(subHeadline)).toBeInTheDocument();
-        expect(getByText(disclaimer)).toBeInTheDocument();
+            expect(getByAltText('PayPal Credit logo')).toHaveAttribute('src', logoSrc);
+        });
+        const getMatchPattern = (cssSelector, cssValue) => {
+            // convert plain string css into an array if RegExps
+            const matchCssValue =
+                cssValue
+                    ?.replace(/\s*\{\s*/, '[^\\{]*{[^\\}]*')
+                    .replace(/;\s*\}\s*/, ';[^\\}]*}')
+                    .replace(/\(/g, '\\(')
+                    .replace(/\)/g, '\\)')
+                    .replace(/ /, '\\s*') || '';
+            const matchCssRules = cssSelector
+                .split(',')
+                .map(selectorPattern =>
+                    RegExp(
+                        selectorPattern
+                            .trim()
+                            .replace(/\./g, '\\.')
+                            .replace(/\(/g, '\\(')
+                            .replace(/\)/g, '\\)')
+                            .replace(/ +/g, '[^,\\{]') + matchCssValue || ''
+                    )
+                )
+                .filter(e => e);
+            return matchCssRules;
+        };
+        const getRenderStyles = (logger, opts, markup, layout, prop, value) => {
+            // get the css rules used when rendered with the specified options
+            if (typeof value !== 'undefined') {
+                objectSet(opts, 'style.layout', layout);
+                objectSet(opts, prop, value);
+            }
+            const { container } = render(<Message locale="US" addLog={logger} options={opts} markup={markup} />);
+            // const style = Array.from(container.querySelectorAll('style'))
+            //     .map(e => e.textContent)
+            //     .join('\n');
+            const style = container.querySelector('.styles__customFont')?.textContent;
+            return style || '';
+        };
+        const scenarios = {
+            DEFAULT: 'default value',
+            VALID: 'valid value',
+            INVALID: 'invalid value',
+            MALICIOUS: 'malicious value'
+        };
+        const flexSelector = `
+            .message__messaging .message__headline span,
+            .message__messaging .message__sub-headline span,
+            .message__messaging .message__disclaimer span`;
+        const textSelector = `.message__messaging`;
+        const fontFaceSelector = '@font-face';
+        const fontFamilyData = {
+            'default value': [undefined, null],
+            'valid value': ['Impact', "{ font-family: 'Impact', PayPal-Sans-Big, PayPal-Sans, Arial, sans-serif; }"],
+            'invalid value': [' ', null],
+            'malicious value': ["</script><script>alert('XSS Message!')</script>", null]
+        };
+        const fontSourceData = {
+            'default value': [undefined, null],
+            'valid value': [
+                ['https://fonts.com/plRP.woff', 'https://fonts.com/plRP.woff2'],
+                "{ src: url('https://fonts.com/plRP.woff') format('woff'), url('https://fonts.com/plRP.woff2') format('woff2'); }"
+            ],
+            // 'valid value': [
+            //     'https://fonts.com/plRP.woff',
+            //     "{ src: url('https://fonts.com/plRP.woff') format('woff'); }"
+            // ],
+            'invalid value': ['https://fonts.com/plRP', null],
+            'malicious value': ["</script><script>alert('XSS Message!')</script>", null]
+        };
+        describe.each([
+            [
+                'text',
+                'text.size',
+                textSelector,
+                {
+                    'default value': [undefined, '{ font-size: 12px; }'],
+                    'valid value': [14, '{ font-size: 14px; }']
+                    // 'invalid value': [48, '{ font-size: 12px; }']
+                }
+            ],
+            [
+                'flex',
+                'text.size',
+                flexSelector,
+                {
+                    'invalid value': [14, null]
+                }
+            ],
+            ['text', 'text.fontFamily', `.message__messaging`, fontFamilyData],
+            ['flex', 'text.fontFamily', flexSelector, fontFamilyData],
+            ['text', 'text.fontSource', fontFaceSelector, fontSourceData],
+            ['flex', 'text.fontSource', fontFaceSelector, fontSourceData]
+        ])('css rule %s.%s', (layout, propString, selector, testValues) => {
+            beforeEach(() => {
+                getLocaleStyles.mockReturnValue([]);
+                getMutations.mockReturnValue([]);
 
-        expect(getByAltText('PayPal Credit logo')).toHaveAttribute('src', logoSrc);
-
-        const customFontStylesContent = container.querySelector('.styles__customFont')?.textContent;
-
-        expect(customFontStylesContent).toMatch(/\.message__messaging[^{]+\{[^}]+font-size: 12px;[^}]+\}/);
+                renderOptions.style = {
+                    layout: 'text',
+                    logo: {
+                        type: 'primary',
+                        position: 'left'
+                    },
+                    text: {
+                        size: 12
+                    }
+                };
+            });
+            const markup = defaultMarkup();
+            const propPath = `style.${propString}`;
+            Array.from(Object.values(scenarios)).map(scenario => {
+                const values = testValues?.[scenario];
+                if (typeof values !== 'undefined') {
+                    return test(scenario, () => {
+                        const [valueIn, valueOut] = values;
+                        const matchPatterns = getMatchPattern(selector, valueOut ?? 'placeholderValue');
+                        const styleRules = getRenderStyles(
+                            mockLogger,
+                            renderOptions,
+                            markup,
+                            layout,
+                            propPath,
+                            valueIn
+                        );
+                        // expect(objectGet(renderOptions, propPath)).toBe(valueIn);
+                        expect(typeof styleRules).toBe('string');
+                        matchPatterns.map(pattern => {
+                            expect(typeof pattern?.source).toBe('string');
+                            if (valueOut) {
+                                return expect(styleRules).toMatch(pattern);
+                            }
+                            return expect(styleRules).not.toMatch(pattern);
+                        });
+                    });
+                }
+                return test.todo(scenario);
+            });
+        });
     });
 
     test('applies cascade mutations', () => {

--- a/tests/unit/spec/server/message/index.test.js
+++ b/tests/unit/spec/server/message/index.test.js
@@ -115,9 +115,9 @@ describe('SSR message', () => {
 
         expect(getByAltText('PayPal Credit logo')).toHaveAttribute('src', logoSrc);
 
-        const miscStyles = Array.from(container.querySelectorAll('style')).find(el => el.className === 'styles__misc');
+        const customFontStylesContent = container.querySelector('.styles__customFont')?.textContent;
 
-        expect(miscStyles.textContent).toBe('.message__messaging { font-size: 12px; }');
+        expect(customFontStylesContent).toMatch(/\.message__messaging[^{]+\{[^}]+font-size: 12px;[^}]+\}/);
     });
 
     test('applies cascade mutations', () => {

--- a/tests/unit/spec/server/message/index.test.js
+++ b/tests/unit/spec/server/message/index.test.js
@@ -149,7 +149,7 @@ describe('SSR message', () => {
                             .replace(/ +/g, '[^,\\{]') + matchCssValue || ''
                     )
                 )
-                .filter(e => e);
+                .filter(Boolean);
             return matchCssRules;
         };
         const getRenderStyles = (logger, opts, markup, layout, prop, value) => {

--- a/tests/unit/spec/server/message/index.test.js
+++ b/tests/unit/spec/server/message/index.test.js
@@ -5,6 +5,8 @@ import { render } from '@testing-library/preact';
 import Message from 'server/message';
 import { getMutations, getLocaleStyles } from 'server/locale';
 
+const mockLogger = jest.fn();
+
 jest.mock('@paypal/sdk-logos/src', () => {
     const mock = () => ({
         render: () => 'src="data:image&#x2F;svg+xml;base64,svg"'
@@ -104,7 +106,7 @@ describe('SSR message', () => {
         );
 
         const { getByText, getByAltText, container } = render(
-            <Message locale="US" options={options} markup={defaultMarkup()} />
+            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
         );
 
         expect(getByText(headline)).toBeInTheDocument();
@@ -157,7 +159,9 @@ describe('SSR message', () => {
             [xsmallSubHeadline, ['xsmall']]
         ];
 
-        const { getByText, queryByText } = render(<Message locale="US" options={options} markup={markup} />);
+        const { getByText, queryByText } = render(
+            <Message locale="US" addLog={mockLogger} options={options} markup={markup} />
+        );
 
         expect(queryByText(headline)).toBeNull();
         expect(queryByText(subHeadline)).toBeNull();
@@ -178,7 +182,9 @@ describe('SSR message', () => {
             ]
         ]);
 
-        const { container } = render(<Message locale="US" options={options} markup={defaultMarkup()} />);
+        const { container } = render(
+            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
+        );
 
         const miscStyles = Array.from(container.querySelectorAll('style')).find(el => el.className === 'styles__misc');
 
@@ -192,7 +198,9 @@ describe('SSR message', () => {
             })
         );
 
-        const { container } = render(<Message locale="US" options={options} markup={defaultMarkup()} />);
+        const { container } = render(
+            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
+        );
 
         const miscStyles = Array.from(container.querySelectorAll('style')).find(el => el.className === 'styles__misc');
 
@@ -205,7 +213,9 @@ describe('SSR message', () => {
             ['logo.type:primary', style2]
         ]);
 
-        const { container } = render(<Message locale="US" options={options} markup={defaultMarkup()} />);
+        const { container } = render(
+            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
+        );
 
         const localeStyles = Array.from(container.querySelectorAll('style')).find(
             el => el.className === 'styles__locale'
@@ -222,7 +232,9 @@ describe('SSR message', () => {
             })
         );
 
-        const { container } = render(<Message locale="US" options={options} markup={defaultMarkup()} />);
+        const { container } = render(
+            <Message locale="US" addLog={mockLogger} options={options} markup={defaultMarkup()} />
+        );
 
         const mutationStyles = Array.from(container.querySelectorAll('style')).find(
             el => el.className === 'styles__mutations'

--- a/tests/unit/spec/src/components/message/parts/Styles.test.js
+++ b/tests/unit/spec/src/components/message/parts/Styles.test.js
@@ -15,6 +15,7 @@ describe('<Styles />', () => {
         const localeStyleRules = ['localeStyleRules'];
         const mutationStyleRules = ['mutationStyleRules'];
         const miscStyleRules = ['miscStyleRules'];
+        const customFontStyleRules = ['customFontStyleRules'];
 
         const { container } = render(
             <Styles
@@ -22,6 +23,7 @@ describe('<Styles />', () => {
                 localeStyleRules={localeStyleRules}
                 mutationStyleRules={mutationStyleRules}
                 miscStyleRules={miscStyleRules}
+                customFontStyleRules={customFontStyleRules}
             />
         );
 
@@ -30,7 +32,8 @@ describe('<Styles />', () => {
             styles__global: globalStyleRules[0],
             styles__locale: localeStyleRules[0],
             styles__mutations: mutationStyleRules[0],
-            styles__misc: miscStyleRules[0]
+            styles__misc: miscStyleRules[0],
+            styles__customFont: customFontStyleRules[0]
         };
 
         const styleTags = container.children;

--- a/utils/devServerProxy/proxy.js
+++ b/utils/devServerProxy/proxy.js
@@ -134,7 +134,11 @@ export default (app, server, compiler) => {
                     }
                 }
 
-                const markup = render({ style: validatedStyle, amount, customMarkup }, populatedBanner);
+                const markup = render(
+                    warnings.push.bind(warnings),
+                    { style: validatedStyle, amount, customMarkup },
+                    populatedBanner
+                );
                 const parentStyles = getParentStyles(validatedStyle);
 
                 return {


### PR DESCRIPTION
Add fontFamily and fontSrc option to text layout.

Allow merchants to pass fontFamily and fontSrc options in order to customize the font for upstream messages.