### PR TITLE
refactor: remove sdk default to USD

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
         'zoid/src': 'zoid',
         'jsx-pragmatic/src': 'jsx-pragmatic',
         '@paypal/sdk-client/src': '@paypal/sdk-client',
+        '@paypal/sdk-constants/src': '@paypal/sdk-constants',
         'belter/src': 'belter'
     },
     collectCoverageFrom: ['./src/**'],

--- a/src/controllers/message/setup.js
+++ b/src/controllers/message/setup.js
@@ -1,6 +1,6 @@
 import stringStartsWith from 'core-js-pure/stable/string/starts-with';
 
-import { getInlineOptions, globalState, getScript, getAccount, getPartnerAccount } from '../../utils';
+import { getInlineOptions, globalState, getScript, getAccount, getCurrency, getPartnerAccount } from '../../utils';
 import Messages from './adapter';
 
 export default function setup() {
@@ -13,6 +13,7 @@ export default function setup() {
         Messages.setGlobalConfig({
             account: partnerAccount || getAccount(),
             merchantId: (partnerAccount && getAccount()) || merchantid,
+            currency: getCurrency(),
             ...inlineScriptOptions
         });
 

--- a/src/controllers/message/setup.js
+++ b/src/controllers/message/setup.js
@@ -1,6 +1,6 @@
 import stringStartsWith from 'core-js-pure/stable/string/starts-with';
 
-import { getInlineOptions, globalState, getScript, getAccount, getCurrency, getPartnerAccount } from '../../utils';
+import { getInlineOptions, globalState, getScript, getAccount, getPartnerAccount } from '../../utils';
 import Messages from './adapter';
 
 export default function setup() {
@@ -13,7 +13,6 @@ export default function setup() {
         Messages.setGlobalConfig({
             account: partnerAccount || getAccount(),
             merchantId: (partnerAccount && getAccount()) || merchantid,
-            currency: getCurrency(),
             ...inlineScriptOptions
         });
 

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,4 +1,6 @@
 /* eslint-disable eslint-comments/disable-enable-pair, no-else-return */
+import { SDK_QUERY_KEYS } from '@paypal/sdk-constants/src';
+
 import {
     getClientID,
     getMerchantID,
@@ -9,6 +11,7 @@ import {
     getSDKQueryParam,
     getNamespace as getSDKNamespace
 } from '@paypal/sdk-client/src';
+
 import 'core-js-pure/stable/object/entries';
 
 // SDK helper functions with standalone build polyfills
@@ -53,7 +56,7 @@ export function getScript() {
 export function getCurrency() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         // Returns 'currency' query param without default to USD
-        return getSDKQueryParam('currency');
+        return getSDKQueryParam(SDK_QUERY_KEYS.CURRENCY);
     } else {
         return undefined;
     }

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -4,15 +4,14 @@ import {
     getMerchantID,
     getSDKScript,
     getEnv as getSDKEnv,
-    getCurrency as getSDKCurrency,
     getSDKMeta,
     getSDKAttributes,
+    getSDKQueryParam,
     getNamespace as getSDKNamespace
 } from '@paypal/sdk-client/src';
 import 'core-js-pure/stable/object/entries';
 
 // SDK helper functions with standalone build polyfills
-
 export function getEnv() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         return getSDKEnv();
@@ -53,7 +52,8 @@ export function getScript() {
 
 export function getCurrency() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
-        return getSDKCurrency();
+        // Returns 'currency' query param without default to USD
+        return getSDKQueryParam('currency');
     } else {
         return undefined;
     }


### PR DESCRIPTION
Removes the use of an SDK utility that defaults to USD when a currency code is not provided.