### PR TITLE
fix: passback warnings

### DIFF
--- a/src/zoid/message/validation.js
+++ b/src/zoid/message/validation.js
@@ -11,6 +11,7 @@ export const Types = {
     BOOLEAN: 'BOOLEAN',
     NUMBER: 'NUMBER',
     FUNCTION: 'FUNCTION',
+    ARRAY: 'ARRAY',
     OBJECT: 'OBJECT'
 };
 
@@ -24,8 +25,10 @@ export function validateType(expectedType, val) {
             return typeof val === 'number' && !numberIsNaN(val);
         case Types.FUNCTION:
             return typeof val === 'function';
+        case Types.ARRAY:
+            return Array.isArray(val);
         case Types.OBJECT:
-            return typeof val === 'object' && val !== null;
+            return !Array.isArray(val) && typeof val === 'object' && val !== null;
         case Types.ANY:
             return true;
         default:
@@ -40,11 +43,13 @@ const logInvalid = memoize((location, message) =>
         location
     })
 );
-const logInvalidType = (location, expectedType, val) =>
+const logInvalidType = (location, expectedType, val) => {
+    const valType = Array.isArray(val) ? 'array' : typeof val;
     logInvalid(
         location,
-        `Expected type "${expectedType.toLowerCase()}" but instead received "${typeof val}" (${val}).`
+        `Expected type "${expectedType.toLowerCase()}" but instead received "${valType}" (${JSON.stringify(val)}).`
     );
+};
 const logInvalidOption = (location, options, val) =>
     logInvalid(location, `Expected one of ["${options.join('", "').replace(/\|[\w|]+/g, '')}"] but received "${val}".`);
 
@@ -115,9 +120,6 @@ export default {
                     ...style
                 };
             }
-        }
-
-        if (validateType(Types.OBJECT, style)) {
             logInvalidType('style.layout', Types.STRING, style.layout);
         } else if (typeof style !== 'undefined') {
             logInvalidType('style', Types.OBJECT, style);


### PR DESCRIPTION
Ensure that invalid style parameters do not prevent a message, and that warnings are presented to merchants in the browser console. 
Pass back warning messages to the browser console when merchants give invalid style parameters.

## Description
Fix edge cases where the style parameter is invalid, but is caught and reported by the sdk rather than cpnw. 

## Motivation and Context
This should provide merchant more information when developing and configuring style parameters. 

## How Has This Been Tested?
I ran the sdk and cpnw locally, then I tested the following 

### Valid attributes

- data-pp-style-text-color=“monochrome”
- data-pp-style-text-size=“16"
- data-pp-style-logo-type=“none”

### Invalid attributes

- data-pp-style-text-size=“16px”
- data-pp-style-texttext-size=“16"
- data-pp-style-size=“16"
- data-pp-style-text-fontsize=“16"
- data-pp-style-colour=“monochrome”
- data-pp-style-text-color=“purple”
- data-pp-style-logo=“none”
- data-pp-style-logo=‘{“type”: null}’
- data-pp-style-logo=‘{“type”: “none”}’ 
- data-pp-style=‘[]’

Confirming warning messages would be passed back when the parameter was invalid. I found that the last variant didn't return an expected warning. 
This should fix the warning message that it returns. All others should be fixed by cpnw#186

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] Did not change the package version
- [x] include relevant documentation/test changes/additions
- [x] PR description should include the type of change
- [ ] ~add an entry into `CHANGELOG.md` under the `## Unreleased` heading like the following~

  - ```
      ## Unreleased
      - something about what was changed or added here
    ```