### PR TITLE
chore: add script namespace feature flag to globals

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -10,12 +10,14 @@ module.exports = (env = { TARGET: 'sdk' }) => ({
         ...zoidGlobals.__ZOID__,
         __DEFAULT_CONTAINER__: true,
         __DEFAULT_PRERENDER__: true,
-        __FRAMEWORK_SUPPORT__: true
+        __FRAMEWORK_SUPPORT__: true,
+        __SCRIPT_NAMESPACE__: false
     },
 
     __POST_ROBOT__: {
         ...postRobotGlobals.__POST_ROBOT__,
-        __IE_POPUP_SUPPORT__: false
+        __IE_POPUP_SUPPORT__: false,
+        __SCRIPT_NAMESPACE__: false
     },
 
     __MESSAGES__: {


### PR DESCRIPTION
This PR adds the new `__SCRIPT_NAMESPACE__` feature flag and sets it to false. It's required by zoid and post-robot to enable name-spacing post message communication with the script uid feature. This is needed to support running multiple version of the JS SDK on the same merchant website.

These flags already exist in paypal-checkout-components here: https://github.com/paypal/paypal-checkout-components/blob/master/globals.js#L8-L21. We need them in messaging-components as well for the use case of a merchant only loading messages (ex: `www.paypal.com/sdk/js?client-id=sb&components=messages`)