### PR TITLE
refactor: update text and flex for Pi3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 
 env:
     global:
-        - DIRTY_SNAPSHOTS=0
+        - DIRTY_SNAPSHOTS=1
     jobs:
         - TEST_PATH_PATTERN=none
 

--- a/banners/GB/pl.json
+++ b/banners/GB/pl.json
@@ -15,10 +15,14 @@
     "headline": [
         [["Buy now, pay later."], ["default", "xsmall"]],
         ["Buy now and pay later.", ["xsmall.2"]],
+        ["Pay in 3 payments on eligible purchases.", ["medium.text", "large.text", "xlarge.text"]],
         ["Pay in 3 interest-free payments on eligible purchases.", ["medium", "large", "xlarge"]]
     ],
 
     "subHeadline": [],
 
-    "disclaimer": [["Learn more", ["default"]]]
+    "disclaimer": [
+        ["Late fees may apply.", ["default.fees"]],
+        ["Learn more", ["default"]]
+    ]
 }

--- a/banners/GB/plq.json
+++ b/banners/GB/plq.json
@@ -16,7 +16,7 @@
         [["Buy now, pay later."], ["default", "xsmall"]],
         ["Buy now and pay later.", ["xsmall.2"]],
         [
-            ["Pay in 3 interest-free payments of {formattedPeriodicPayment}", [".", "weak"]],
+            ["Pay in 3 payments of {formattedPeriodicPayment}", [".", "weak"]],
             ["medium.text", "large.text", "xlarge.text"]
         ],
         [

--- a/banners/GB/plq.json
+++ b/banners/GB/plq.json
@@ -17,11 +17,18 @@
         ["Buy now and pay later.", ["xsmall.2"]],
         [
             ["Pay in 3 interest-free payments of {formattedPeriodicPayment}", [".", "weak"]],
+            ["medium.text", "large.text", "xlarge.text"]
+        ],
+        [
+            ["Pay in 3 interest-free payments of {formattedPeriodicPayment}", [".", "weak"]],
             ["medium", "large", "xlarge"]
         ]
     ],
 
     "subHeadline": [],
 
-    "disclaimer": [["Learn more", ["default"]]]
+    "disclaimer": [
+        ["Late fees may apply.", ["default.fees"]],
+        ["Learn more", ["default"]]
+    ]
 }

--- a/modals/GB/gpl.json
+++ b/modals/GB/gpl.json
@@ -35,7 +35,8 @@
             "apply": "Apply easily and get an instant decision."
         },
         "terms": [
-            "Subject to status. Terms and Conditions apply. UK residents only.",
+            "Subject to status. Terms and Conditions apply. Late fees apply. UK residents only.",
+            "PayPal is a responsible lender. Pay in 3 performance may influence your credit score.",
             "PayPal Pay in 3 is a trading name of PayPal (Europe) S.à.r.l. et Cie, S.C.A.,",
             "22-24 Boulevard Royal, L-2449, Luxembourg."
         ],

--- a/server/locale/GB/mutations/gpl.js
+++ b/server/locale/GB/mutations/gpl.js
@@ -84,7 +84,7 @@ export default {
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 18), `.message__logo { width: ${textSize * 4}px }`],
+                styles: [xSmallFallback(textSize * 16), `.message__logo { width: ${textSize * 4}px }`],
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {

--- a/server/locale/GB/mutations/gpl.js
+++ b/server/locale/GB/mutations/gpl.js
@@ -35,7 +35,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     xSmallFallback(textSize * 16),
-                    setLogoTop(textSize * 36 + 10),
+                    setLogoTop(textSize * 32 + 10),
                     messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
                 ]
             })

--- a/server/locale/GB/mutations/gpl.js
+++ b/server/locale/GB/mutations/gpl.js
@@ -22,7 +22,7 @@ export default {
                 logo: Logo.PP_PAYPAL.COLOR,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['on']
                     },
                     { tag: 'xsmall' }
@@ -66,7 +66,7 @@ export default {
                 logo: false,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['on'],
                         replace: [
                             ['purchases.', 'purchases'],
@@ -88,7 +88,7 @@ export default {
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['on'],
                         replace: [
                             ['purchases.', 'purchases'],
@@ -119,7 +119,7 @@ export default {
                         tag: 'medium'
                     }
                 ],
-                disclaimer: ['default']
+                disclaimer: ['default.fees', 'default']
             }
         ],
         [

--- a/server/locale/GB/mutations/gplq.js
+++ b/server/locale/GB/mutations/gplq.js
@@ -37,7 +37,7 @@ export default {
                     `@media screen and (max-width: ${textSize *
                         14.15}px) { .message__headline > .tag--medium > span > span:first-child { white-space: normal; } }`,
                     xSmallFallback(textSize * 10.75),
-                    setLogoTop(textSize * 32 + 10),
+                    setLogoTop(textSize * 26 + 10),
                     messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
                 ]
             })

--- a/server/locale/GB/mutations/gplq.js
+++ b/server/locale/GB/mutations/gplq.js
@@ -22,7 +22,7 @@ export default {
                 logo: Logo.PP_PAYPAL.COLOR,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['payments']
                     },
                     { tag: 'xsmall' }
@@ -73,7 +73,7 @@ export default {
                 logo: false,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['on'],
                         replace: [['purchases.', 'purchases']]
                     },
@@ -91,7 +91,7 @@ export default {
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {
-                        tag: 'medium',
+                        tag: 'medium.text',
                         br: ['on'],
                         replace: [['purchases.', 'purchases']]
                     },
@@ -118,7 +118,7 @@ export default {
                         tag: 'medium'
                     }
                 ],
-                disclaimer: ['default'],
+                disclaimer: ['default.fees', 'default'],
                 styles: [
                     '.message__headline .tag--medium > span:first-child:after { content: "."; }',
                     '.message__headline .tag--medium .weak { display: none; }'

--- a/server/locale/GB/mutations/gplq.js
+++ b/server/locale/GB/mutations/gplq.js
@@ -17,7 +17,8 @@ export default {
                 styles: [
                     xSmallFallback(textSize * 16),
                     textWrap(textSize * 32, textSize, 'GB'),
-                    messageLogoWidth(false, textSize * 4, textSize * 1.25)
+                    messageLogoWidth(false, textSize * 4, textSize * 1.25),
+                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
                 ],
                 logo: Logo.PP_PAYPAL.COLOR,
                 headline: [
@@ -38,7 +39,8 @@ export default {
                         14.15}px) { .message__headline > .tag--medium > span > span:first-child { white-space: normal; } }`,
                     xSmallFallback(textSize * 10.75),
                     setLogoTop(textSize * 26 + 10),
-                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
+                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25),
+                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
                 ]
             })
         ],
@@ -49,7 +51,8 @@ export default {
                     `@media screen and (max-width: ${textSize *
                         14.15}px) { .message__headline > .tag--medium > span > span:first-child { white-space: normal; } }`,
                     xSmallFallback(textSize * 10.75),
-                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
+                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25),
+                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
                 ]
             })
         ],
@@ -61,7 +64,8 @@ export default {
                     textWrap(textSize * 32, textSize, 'GB'),
                     xSmallFallback(textSize * 11.5),
                     altNoWrap(textSize * 10.6),
-                    messageLogoWidth(textSize * 1.75, textSize * 4, textSize * 1.25)
+                    messageLogoWidth(textSize * 1.75, textSize * 4, textSize * 1.25),
+                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
                 ],
                 logo: Logo.PP_PAYPAL.COLOR[0]
             })
@@ -69,7 +73,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 18)],
+                styles: [xSmallFallback(textSize * 14)],
                 logo: false,
                 headline: [
                     {
@@ -87,7 +91,7 @@ export default {
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 18), `.message__logo { width: ${textSize * 4}px }`],
+                styles: [xSmallFallback(textSize * 14), `.message__logo { width: ${textSize * 4}px }`],
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {

--- a/server/locale/GB/styles/flex/base.css
+++ b/server/locale/GB/styles/flex/base.css
@@ -23,8 +23,8 @@
     white-space: nowrap;
 }
 
-.message__disclaimer > span > span:only-child,
-.message__disclaimer > span > span.em {
+.message__disclaimer > span:last-child > span:only-child,
+.message__disclaimer > span:last-child > span.em {
     text-decoration: underline;
 }
 

--- a/server/locale/GB/styles/flex/ratio--20x1.css
+++ b/server/locale/GB/styles/flex/ratio--20x1.css
@@ -119,3 +119,9 @@
         font-size: 10px;
     }
 }
+
+@media (max-aspect-ratio: 61 / 10) and (min-width: 375px) {
+    .message__disclaimer > span:first-child {
+        display: inline;
+    }
+}

--- a/server/locale/GB/styles/flex/ratio--20x1.css
+++ b/server/locale/GB/styles/flex/ratio--20x1.css
@@ -1,3 +1,7 @@
+.message__disclaimer > span:first-child {
+    display: none;
+}
+
 @media (min-aspect-ratio: 200/11) {
     .message__logo-container {
         margin-bottom: -3px;
@@ -74,6 +78,10 @@
     }
 
     .message__headline span.multi:nth-of-type(2) {
+        display: inline;
+    }
+
+    .message__disclaimer > span:first-child {
         display: inline;
     }
 }

--- a/server/locale/GB/styles/flex/ratio--8x1.css
+++ b/server/locale/GB/styles/flex/ratio--8x1.css
@@ -1,3 +1,7 @@
+.message__disclaimer > span:first-child {
+    display: none;
+}
+
 @media (min-aspect-ratio: 80/11) {
     .message__headline {
         display: inline;
@@ -21,10 +25,6 @@
         width: 50%;
         margin-left: 10px;
         margin-right: 0;
-    }
-
-    .message__disclaimer {
-        margin-left: 1%;
     }
 }
 
@@ -52,6 +52,14 @@
     .message__headline > span:nth-of-type(3) {
         display: inline;
     }
+
+    .message__disclaimer {
+        margin-left: 1%;
+    }
+
+    .message__disclaimer > span:first-child {
+        display: inline;
+    }
 }
 
 @media (min-aspect-ratio: 80/11) and (min-width: 351px) {
@@ -69,5 +77,11 @@
 @media (min-aspect-ratio: 80/11) and (min-width: 360px) {
     .message__messaging {
         line-height: 1.3rem;
+    }
+}
+
+@media (max-aspect-ratio: 61 / 10) and (min-width: 375px) {
+    .message__disclaimer > span:first-child {
+        display: inline;
     }
 }

--- a/src/components/modal/content/GB/parts/PL.jsx
+++ b/src/components/modal/content/GB/parts/PL.jsx
@@ -45,6 +45,15 @@ const PL = () => {
                             <br />
                         </Fragment>
                     ))}
+                    Click{' '}
+                    <a
+                        href="https://www.paypal.com/uk/webapps/mpp/paypal-payin3/faq"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        here
+                    </a>{' '}
+                    to learn more about Pay in 3.
                 </p>
             </div>
         </section>


### PR DESCRIPTION
The wrapping logic for text messages seemed to be fairly solid as is. Primary Left seems like there's a lot of space on the right but if I change the wrapping, it's only enough room for `eligible` to appear on the top line and it still has plenty of space on the right.