### PR TITLE
fix: overflow 0px fix 

### DIFF
--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -354,7 +354,7 @@ export const getRoot = baseElement => {
             // Ensure that the selected root is the larger of the parent
             // and contains the child otherwise there may not be a proper page wrapper
             // e.g. https://www.acwholesalers.com
-            (child && child.offsetHeight < height && elementContains(el.parentNode, el))
+            (child && child.offsetHeight !== 0 && child.offsetHeight < height && elementContains(el.parentNode, el))
         );
     });
 


### PR DESCRIPTION
this isssue is related to merchants having problems with the 
`"PayPal Message attempting fallback. Message must be visible and requires minimum dimensions of 0px x 0px. Current container is 0px x 0px."`

checks to make sure that the Root element does not have a height of 0px. If it does, it will use the next child element. 

this is a possible fix not finalized
