### PR TITLE
chore: clear loose warning

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,5 +4,6 @@ module.exports = {
         test: {
             presets: [['@babel/env', { targets: { node: 'current' } }]]
         }
-    }
+    },
+    plugins: [['@babel/plugin-proposal-private-methods', { loose: true }]]
 };


### PR DESCRIPTION
Prevent  "loose" warning from showing up in the CI and in local test logs.