### PR TITLE
fix: use unformatted APR number to choose DE disclosure [snapshots]

### DIFF
--- a/server/render.jsx
+++ b/server/render.jsx
@@ -5,5 +5,6 @@ import render from 'preact-render-to-string';
 import Message from './message';
 
 export default (options, markup, addLog) => {
+    // eslint-disable-next-line react/destructuring-assignment
     return render(<Message addLog={addLog} options={options} markup={markup} locale={markup.meta.offerCountry} />);
 };

--- a/src/components/modal/content/DE-GPL/parts/GPL.jsx
+++ b/src/components/modal/content/DE-GPL/parts/GPL.jsx
@@ -19,7 +19,7 @@ export default () => {
             </div>
 
             <div className="content-column disclosure transitional">
-                {(apr === '0,00' ? disclosure.zeroAPR : disclosure.nonZeroAPR).replace(/,00/g, '')}
+                {(apr === '0.00' ? disclosure.zeroAPR : disclosure.nonZeroAPR).replace(/[.,]00/g, '')}
             </div>
         </section>
     );


### PR DESCRIPTION
APR formatting now uses 0.00 instead of 0,00 to match formatting from MORS.