### PR TITLE
refactor: add interest-free back into Pi3 [snapshots]

### DIFF
--- a/server/locale/GB/mutations/gpl.js
+++ b/server/locale/GB/mutations/gpl.js
@@ -35,7 +35,7 @@ export default {
             ({ textSize }) => ({
                 styles: [
                     xSmallFallback(textSize * 16),
-                    setLogoTop(textSize * 32 + 10),
+                    setLogoTop(textSize * 36 + 10),
                     messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
                 ]
             })
@@ -84,7 +84,7 @@ export default {
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 16), `.message__logo { width: ${textSize * 4}px }`],
+                styles: [xSmallFallback(textSize * 18), `.message__logo { width: ${textSize * 4}px }`],
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {

--- a/server/locale/GB/mutations/gplq.js
+++ b/server/locale/GB/mutations/gplq.js
@@ -17,8 +17,7 @@ export default {
                 styles: [
                     xSmallFallback(textSize * 16),
                     textWrap(textSize * 32, textSize, 'GB'),
-                    messageLogoWidth(false, textSize * 4, textSize * 1.25),
-                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
+                    messageLogoWidth(false, textSize * 4, textSize * 1.25)
                 ],
                 logo: Logo.PP_PAYPAL.COLOR,
                 headline: [
@@ -38,9 +37,8 @@ export default {
                     `@media screen and (max-width: ${textSize *
                         14.15}px) { .message__headline > .tag--medium > span > span:first-child { white-space: normal; } }`,
                     xSmallFallback(textSize * 10.75),
-                    setLogoTop(textSize * 26 + 10),
-                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25),
-                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
+                    setLogoTop(textSize * 32 + 10),
+                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
                 ]
             })
         ],
@@ -51,8 +49,7 @@ export default {
                     `@media screen and (max-width: ${textSize *
                         14.15}px) { .message__headline > .tag--medium > span > span:first-child { white-space: normal; } }`,
                     xSmallFallback(textSize * 10.75),
-                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25),
-                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
+                    messageLogoWidth(textSize * 6, textSize * 4, textSize * 1.25)
                 ]
             })
         ],
@@ -64,8 +61,7 @@ export default {
                     textWrap(textSize * 32, textSize, 'GB'),
                     xSmallFallback(textSize * 11.5),
                     altNoWrap(textSize * 10.6),
-                    messageLogoWidth(textSize * 1.75, textSize * 4, textSize * 1.25),
-                    `.message__headline > .tag--medium > span:not(.weak):first-child {white-space: nowrap;}`
+                    messageLogoWidth(textSize * 1.75, textSize * 4, textSize * 1.25)
                 ],
                 logo: Logo.PP_PAYPAL.COLOR[0]
             })
@@ -73,7 +69,7 @@ export default {
         [
             'logo.type:none',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 14)],
+                styles: [xSmallFallback(textSize * 18)],
                 logo: false,
                 headline: [
                     {
@@ -91,7 +87,7 @@ export default {
         [
             'logo.type:inline',
             ({ textSize }) => ({
-                styles: [xSmallFallback(textSize * 14), `.message__logo { width: ${textSize * 4}px }`],
+                styles: [xSmallFallback(textSize * 18), `.message__logo { width: ${textSize * 4}px }`],
                 logo: Logo.NO_PP_MONOGRAM.COLOR,
                 headline: [
                     {

--- a/server/locale/GB/styles/flex/base.css
+++ b/server/locale/GB/styles/flex/base.css
@@ -23,8 +23,8 @@
     white-space: nowrap;
 }
 
-.message__disclaimer > span:last-child > span:only-child,
-.message__disclaimer > span:last-child > span.em {
+.message__disclaimer > span > span:only-child,
+.message__disclaimer > span > span.em {
     text-decoration: underline;
 }
 

--- a/server/locale/GB/styles/flex/ratio--20x1.css
+++ b/server/locale/GB/styles/flex/ratio--20x1.css
@@ -1,7 +1,3 @@
-.message__disclaimer > span:first-child {
-    display: none;
-}
-
 @media (min-aspect-ratio: 200/11) {
     .message__logo-container {
         margin-bottom: -3px;
@@ -80,10 +76,6 @@
     .message__headline span.multi:nth-of-type(2) {
         display: inline;
     }
-
-    .message__disclaimer > span:first-child {
-        display: inline;
-    }
 }
 
 @media (min-aspect-ratio: 200/11) and (max-width: 600px) {
@@ -117,11 +109,5 @@
 @media (min-aspect-ratio: 200/11) and (max-width: 350px) {
     .message__headline {
         font-size: 10px;
-    }
-}
-
-@media (max-aspect-ratio: 61 / 10) and (min-width: 375px) {
-    .message__disclaimer > span:first-child {
-        display: inline;
     }
 }

--- a/server/locale/GB/styles/flex/ratio--8x1.css
+++ b/server/locale/GB/styles/flex/ratio--8x1.css
@@ -1,7 +1,3 @@
-.message__disclaimer > span:first-child {
-    display: none;
-}
-
 @media (min-aspect-ratio: 80/11) {
     .message__headline {
         display: inline;
@@ -25,6 +21,10 @@
         width: 50%;
         margin-left: 10px;
         margin-right: 0;
+    }
+
+    .message__disclaimer {
+        margin-left: 1%;
     }
 }
 
@@ -52,14 +52,6 @@
     .message__headline > span:nth-of-type(3) {
         display: inline;
     }
-
-    .message__disclaimer {
-        margin-left: 1%;
-    }
-
-    .message__disclaimer > span:first-child {
-        display: inline;
-    }
 }
 
 @media (min-aspect-ratio: 80/11) and (min-width: 351px) {
@@ -77,11 +69,5 @@
 @media (min-aspect-ratio: 80/11) and (min-width: 360px) {
     .message__messaging {
         line-height: 1.3rem;
-    }
-}
-
-@media (max-aspect-ratio: 61 / 10) and (min-width: 375px) {
-    .message__disclaimer > span:first-child {
-        display: inline;
     }
 }


### PR DESCRIPTION
Add 'interest-free' back into GB GPL messages, and remove mentions of late fees.

[Original PR](https://github.com/paypal/paypal-messaging-components/pull/595)