### PR TITLE
build: remove static namespace from SDK meta file

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -3,7 +3,6 @@ const globals = require('./globals');
 module.exports = {
     messages: {
         entry: './src/interface',
-        staticNamespace: '__messages__',
         globals: globals({ TARGET: 'sdk' })
     }
 };


### PR DESCRIPTION
This is a continuation of this work: https://github.com/paypal/paypal-common-components/pull/30

That PR also includes why we are doing this.

This does not impact the global `__MESSAGES__` object. That is still in use and will still be included. This is only removing the unused `__messages__` static namespace which wasn't being used in this repo or any other repo

Also, please tag anyone you think is relevant on this PR. I just included the suggested reviewers and my direct team.