### PR TITLE
fix: locale parity

### DIFF
--- a/server/message/mediaQueries.js
+++ b/server/message/mediaQueries.js
@@ -1,7 +1,7 @@
 // Media queries shared across numerous locales. All other media queries should be placed in their specific locale folders.
 
 /**
- * Used for primary and alternative GPL US/GB styles in order to fallback to the .tag--xsmall message.
+ * Used for primary and alternative GPL styles in order to fallback to the .tag--xsmall message.
  */
 export function xSmallFallback(breakpoint) {
     return `

--- a/tests/functional/spec/globalModalTestDefs.js
+++ b/tests/functional/spec/globalModalTestDefs.js
@@ -3,8 +3,8 @@ import { logTestName } from './utils/logging';
 import modalSnapshot from './utils/modalSnapshot';
 
 /**
- * General modal function tests for the US, DE, and GB locales.
- * Runs inside of modalText and modalFlex test files for the US, DE, and GB locales.
+ * General modal function tests for the locales.
+ * Runs inside of modalText and modalFlex test files for the locales.
  */
 
 export const xClosesModal = ({ account, viewport, groupString }) => async () => {

--- a/tests/unit/spec/server/locale/index.test.js
+++ b/tests/unit/spec/server/locale/index.test.js
@@ -119,12 +119,24 @@ jest.mock('server/locale/GB/mutations/gplq', () => ({
     'layout:flex': ['flex', 'GB', 'PLQ']
 }));
 
+jest.mock('server/locale/FR/mutations/gpl', () => ({
+    'layout:text': ['text', 'FR', 'GPL'],
+    'layout:flex': ['flex', 'FR', 'GPL']
+}));
+
+jest.mock('server/locale/FR/mutations/gplq', () => ({
+    'layout:text': ['text', 'FR', 'GPLQ'],
+    'layout:flex': ['flex', 'FR', 'GPLQ']
+}));
+
 jest.mock('server/locale/AU/mutations/gpl', () => ({
-    'layout:text': ['text', 'AU', 'GPL']
+    'layout:text': ['text', 'AU', 'GPL'],
+    'layout:flex': ['flex', 'AU', 'GPL']
 }));
 
 jest.mock('server/locale/AU/mutations/gplq', () => ({
-    'layout:text': ['text', 'AU', 'GPLQ']
+    'layout:text': ['text', 'AU', 'GPLQ'],
+    'layout:flex': ['flex', 'AU', 'GPLQ']
 }));
 
 describe('locale methods', () => {
@@ -161,7 +173,11 @@ describe('locale methods', () => {
             ['DE', 'PI30'],
             ['DE', 'PI30Q'],
             ['GB', 'PL'],
-            ['GB', 'PLQ']
+            ['GB', 'PLQ'],
+            ['FR', 'GPL'],
+            ['FR', 'GPLQ'],
+            ['AU', 'GPL'],
+            ['AU', 'GPLQ']
         ])('returns correct mutations %s %s', (locale, offerType) => {
             const textMutations = getMutations(locale, offerType, 'layout:text', {});
             expect(textMutations).toEqual(['text', locale, offerType]);


### PR DESCRIPTION
AU and FR were missing from `tests/unit/spec/server/locale/index.test.js` and updated some comments to refer to locales in general. 