### PR TITLE
fix: GB inline and none mutation rule for purchase range message

### DIFF
--- a/src/server/locale/GB/mutations/gpl.js
+++ b/src/server/locale/GB/mutations/gpl.js
@@ -75,7 +75,7 @@ export default {
                         br: ['purchases'],
                         replace: [
                             ['purchases.', 'purchases'],
-                            ['£5,000.', '£5,000'],
+                            ['0.', '0'],
                             ['later.', 'later']
                         ]
                     },
@@ -104,7 +104,7 @@ export default {
                         br: ['purchases'],
                         replace: [
                             ['purchases.', 'purchases'],
-                            ['£5,000.', '£5,000'],
+                            ['0.', '0'],
                             ['later.', 'later']
                         ]
                     },


### PR DESCRIPTION
Change has already included in the asset deploy hotfix on 3/18/22. 