### PR TITLE
fix: Adds merchantConfigHash to the query parameters on subsequent re-renders of message

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -35,7 +35,8 @@ const Message = function({ markup, meta, parentStyles, warnings }) {
         offer: window.xprops.offer ?? null,
         payerId: window.xprops.payerId ?? null,
         clientId: window.xprops.clientId ?? null,
-        merchantId: window.xprops.merchantId ?? null
+        merchantId: window.xprops.merchantId ?? null,
+        merchantConfigHash: window.xprops.merchantConfigHash ?? null
     });
 
     const [serverData, setServerData] = createState({
@@ -129,7 +130,8 @@ const Message = function({ markup, meta, parentStyles, warnings }) {
                     env,
                     features,
                     stageTag,
-                    style
+                    style,
+                    merchantConfigHash
                 } = xprops;
 
                 setProps({
@@ -141,7 +143,8 @@ const Message = function({ markup, meta, parentStyles, warnings }) {
                     offer,
                     payerId,
                     clientId,
-                    merchantId
+                    merchantId,
+                    merchantConfigHash
                 });
 
                 // Generate new MRID on message update.
@@ -161,7 +164,8 @@ const Message = function({ markup, meta, parentStyles, warnings }) {
                     features,
                     version,
                     env,
-                    stageTag
+                    stageTag,
+                    merchantConfigHash
                 })
                     .filter(([, val]) => Boolean(val))
                     .reduce(

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -165,7 +165,7 @@ const Message = function({ markup, meta, parentStyles, warnings }) {
                     version,
                     env,
                     stageTag,
-                    merchantConfigHash
+                    merchant_config: merchantConfigHash
                 })
                     .filter(([, val]) => Boolean(val))
                     .reduce(


### PR DESCRIPTION
This addresses the issue where the merchant config hash was not being passed along in the query params for subsequent message re-renders, this will allow it to hit the cache instead of missing.