### PR TITLE
fix: meta viewport restoration

### DIFF
--- a/src/utils/miscellaneous.js
+++ b/src/utils/miscellaneous.js
@@ -147,7 +147,7 @@ export const getCurrentTime = () => new Date().getTime();
 // Memoized so that the 2 return functions can be called from different modules
 export const viewportHijack = memoize(() => {
     const viewport =
-        document.head.querySelector('meta[name="viewport"]') ||
+        document.querySelector('meta[name="viewport"]') ||
         (<meta name="viewport" content="" />).render(dom({ doc: document }));
 
     // Ensure a viewport exists in the DOM


### PR DESCRIPTION
Changed it to handle in case the there is an existing `<meta name="viewport">` element, but the element is not within the `<head>`.