### PR TITLE
chore: upgrade to grumbler-scripts@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@babel/eslint-parser": "^7.17.0",
         "@babel/register": "^7.10.4",
         "@babel/runtime": "7.12.18",
-        "@krakenjs/grumbler-scripts": "^6.0.2",
+        "@krakenjs/grumbler-scripts": "^7.0.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",


### PR DESCRIPTION
This is a major version bump of grumbler-scripts which includes the
following high level changes:

- switch from node-sass to dart sass package (potentially breaking for this repo)
- removal of flow-runtime setup (unused) (non-breaking for this repo)
- remove eslint style rules in favor of folks using prettier
  (non-breaking for this repo)

You can view the full changelog here: https://github.com/krakenjs/grumbler-scripts/blob/77677619319df45479cf49b1fb95af63acbed7f0/CHANGELOG.md