### PR TITLE
fix: snapshotCommit workflow

### DIFF
--- a/.github/workflows/snapshotCommit.yml
+++ b/.github/workflows/snapshotCommit.yml
@@ -15,7 +15,6 @@ jobs:
             - name: Checkout repo
               uses: actions/checkout@v3
               with:
-                  persist-credentials: false
                   ref: ${{ github.event.workflow_run.head_branch }}
                   repository: ${{ github.event.workflow_run.head_repository.full_name }}
                   token: ${{ secrets.COMMIT_TOKEN }}


### PR DESCRIPTION
Removing `persist-credentials: false` from snapshotCommit because it needs the credentials to be able to generate a commit. 

[Failed job example](https://github.com/paypal/paypal-messaging-components/runs/7411592411?check_suite_focus=true)