### PR TITLE
fix: prevent DE LT view from displaying product list tiles

### DIFF
--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -65,7 +65,7 @@ const getError = ({ offers, error = '' }, isLoading, calculator, amount, country
     return null;
 };
 
-const Calculator = ({ setExpandedState, calculator, disclaimer: { zeroAPR, mixedAPR, nonZeroAPR }, setAPRType }) => {
+const Calculator = ({ setExpandedState, calculator, aprDisclaimer }) => {
     const { view, value, isLoading, submit, changeInput } = useCalculator({ autoSubmit: true });
     const { amount } = useXProps();
     const { country, views } = useServerData();
@@ -159,38 +159,6 @@ const Calculator = ({ setExpandedState, calculator, disclaimer: { zeroAPR, mixed
         }
         return <Fragment />;
     };
-
-    /**
-     * Checks qualifying offer APRs in order to determine which APR disclaimer to render.
-     */
-    const { offers } = view;
-    let aprDisclaimer = '';
-
-    const aprArr = offers.filter(offer => offer?.meta?.qualifying === 'true').map(offer => offer?.meta?.apr);
-
-    if (aprArr.length > 0) {
-        if (aprArr.filter(apr => apr.replace('.00', '') !== '0').length === aprArr.length) {
-            aprDisclaimer = nonZeroAPR;
-            setAPRType('nonZeroAPR');
-        } else if (aprArr.filter(apr => apr.replace('.00', '') === '0').length === aprArr.length) {
-            aprDisclaimer = zeroAPR;
-            setAPRType('zeroAPR');
-        } else {
-            aprDisclaimer = mixedAPR;
-        }
-    } else {
-        /**
-         * Specifically, this impacts US Long Term and which legal disclaimer shows underneath the offer cards.
-         * If no initial amount is passed in or there is an error, we default to the zeroAPR disclaimer as it is more
-         * generic. i.e. Terms may vary based on purchase amount.
-         */
-        aprDisclaimer = zeroAPR;
-        /**
-         * setAPRType is used by DE Long Term to determine which legal disclosure shows at the bottom of the modal.
-         * If no initial amount is passed in, set the default legal disclosure to the nonZeroAPR disclosure.
-         */
-        setAPRType('nonZeroAPR');
-    }
 
     /**
      * Due to slight differences in the calculator input styling between

--- a/src/components/modal/v2/parts/views/LongTerm/Content.jsx
+++ b/src/components/modal/v2/parts/views/LongTerm/Content.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, Fragment } from 'preact';
 import { useState } from 'preact/hooks';
-import { useXProps, useServerData, useCalculator, getComputedVariables } from '../../../lib';
+import { useXProps, useServerData, getComputedVariables } from '../../../lib';
 import Calculator from '../../Calculator';
 import ProductListLink from '../../ProductListLink';
 import Instructions from '../../Instructions';
@@ -12,7 +12,6 @@ import styles from './styles.scss';
 /**
  * Checks qualifying offer APRs in order to determine which APR disclaimer to render.
  */
-
 const getAPRDetails = ({ offers, disclaimer: { zeroAPR, mixedAPR, nonZeroAPR } }) => {
     const qualifyingOffers = offers.filter(offer => offer?.meta?.qualifying === 'true');
 
@@ -56,7 +55,7 @@ const getAPRDetails = ({ offers, disclaimer: { zeroAPR, mixedAPR, nonZeroAPR } }
          */
         aprDisclaimer: zeroAPR,
         /**
-         * setAPRType is used by DE Long Term to determine which legal disclosure shows at the bottom of the modal.
+         * Used by DE Long Term to determine which legal disclosure shows at the bottom of the modal.
          * If no initial amount is passed in, set the default legal disclosure to the nonZeroAPR disclosure.
          */
         aprType: 'nonZeroAPR'
@@ -70,9 +69,7 @@ export const LongTerm = ({
     const [expandedState, setExpandedState] = useState(false);
     const { amount, onClick, onClose } = useXProps();
     const { views, country } = useServerData();
-    const {
-        view: { offers }
-    } = useCalculator();
+    const { offers } = views.find(view => view.offers);
     const { minAmount, maxAmount } = getComputedVariables(offers);
     const { aprDisclaimer, aprType } = getAPRDetails({ offers, disclaimer });
 

--- a/src/components/modal/v2/parts/views/LongTerm/Content.jsx
+++ b/src/components/modal/v2/parts/views/LongTerm/Content.jsx
@@ -153,7 +153,7 @@ export const LongTerm = ({
                 <Instructions instructions={instructions} expandedState={expandedState} />
             </div>
             <div className={`content__row disclosure ${expandedState ? '' : 'collapsed'}`}>
-                {typeof disclosure === 'string' ? (
+                {typeof disclosure === 'string' || Array.isArray(disclosure) ? (
                     <InlineLinks text={disclosure} />
                 ) : (
                     <InlineLinks text={(disclosure?.[aprType] ?? '').replace(/\D00\s?EUR/g, ' €')} />

--- a/src/components/modal/v2/parts/views/LongTerm/Content.jsx
+++ b/src/components/modal/v2/parts/views/LongTerm/Content.jsx
@@ -153,10 +153,10 @@ export const LongTerm = ({
                 <Instructions instructions={instructions} expandedState={expandedState} />
             </div>
             <div className={`content__row disclosure ${expandedState ? '' : 'collapsed'}`}>
-                {typeof disclosure !== 'string' && aprType && aprType in disclosure ? (
-                    <InlineLinks text={disclosure[aprType].replace(/\D00\s?EUR/g, ' €')} />
-                ) : (
+                {typeof disclosure === 'string' ? (
                     <InlineLinks text={disclosure} />
+                ) : (
+                    <InlineLinks text={(disclosure?.[aprType] ?? '').replace(/\D00\s?EUR/g, ' €')} />
                 )}
             </div>
             {renderCheckoutCtaButton()}


### PR DESCRIPTION
Summary of the issue: The initial `useState` value of `''` is causing the modal to error out. When this occurs:
https://github.com/paypal/paypal-messaging-components/blob/b2e38445a97912bcb76488cfb6c70e5420e24fde/src/components/modal/v2/parts/views/LongTerm/Content.jsx#L156
resolves to `''` which is falsey and resolves to the incorrect branch: 
https://github.com/paypal/paypal-messaging-components/blob/b2e38445a97912bcb76488cfb6c70e5420e24fde/src/components/modal/v2/parts/views/LongTerm/Content.jsx#L159
which results in an object being passed in instead of a supported string or array of strings which causes the error to be thrown and halt the rendering. The `setState` of the "empty" `useState` is immediately called inside the `Calculator` forces an unnecessary rerender, so the dependency inside `Calculator` has been pulled up into the LT view and then passes what's needed into `Calculator` instead so that the LT view has all the info it needs on the first render.