### PR TITLE
ci: remove use of deprecated set-output command

### DIFF
--- a/.github/workflows/snapshotCompare.yml
+++ b/.github/workflows/snapshotCompare.yml
@@ -24,12 +24,12 @@ jobs:
             - id: setTestPathPatterns
               name: Set test path patterns
               run: |
-                  echo "::set-output name=testPathPatterns::$(./.github/scripts/getTestPathPatterns.sh)"
+                  echo "testPathPatterns=$(./.github/scripts/getTestPathPatterns.sh)" >> $GITHUB_OUTPUT
 
             - id: setTestConfigs
               name: Set test config environment variables
               run: |
-                  echo "::set-output name=testConfigs::$(./.github/scripts/getTestConfigs.sh)"
+                  echo "testConfigs=$(./.github/scripts/getTestConfigs.sh)" >> $GITHUB_OUTPUT
 
     compareSnapshots:
         name: Compare

--- a/.github/workflows/snapshotUpdate.yml
+++ b/.github/workflows/snapshotUpdate.yml
@@ -21,12 +21,12 @@ jobs:
 
             - id: setTestPathPatterns
               run: |
-                  echo "::set-output name=testPathPatterns::$(./.github/scripts/getTestPathPatterns.sh)"
+                  echo "testPathPatterns=$(./.github/scripts/getTestPathPatterns.sh)" >> $GITHUB_OUTPUT
 
             - id: setTestConfigs
               name: Set test config environment variables
               run: |
-                  echo "::set-output name=testConfigs::$(./.github/scripts/getTestConfigs.sh)"
+                  echo "testConfigs=$(./.github/scripts/getTestConfigs.sh)" >> $GITHUB_OUTPUT
 
     captureMetadata:
         name: Capture Metadata
@@ -82,15 +82,15 @@ jobs:
               run: |
                   if [ -z "$(git status --porcelain)" ]
                   then
-                      echo "::set-output name=skip::true"
+                      echo "skip=true" >> $GITHUB_OUTPUT
                       exit 0
                   fi
 
                   ARTIFACT_NAME="snapshot-$(sed 's/\//-/g' <<< '${{ matrix.testPathPattern }}')"
-                  echo "::set-output name=name::$ARTIFACT_NAME"
+                  echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
 
                   ARTIFACT_PATH="snapshots/"
-                  echo "::set-output name=filePath::$ARTIFACT_PATH"
+                  echo "filePath=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
 
                   UPDATED_SNAPSHOTS=$(git status --porcelain | grep 'snapshots' | sed -E "s/^.{3}//")
                   echo "$UPDATED_SNAPSHOTS" | while read -r filePath
@@ -163,15 +163,15 @@ jobs:
               run: |
                   if [ -z "$(git status --porcelain)" ]
                   then
-                      echo "::set-output name=skip::true"
+                      echo "skip=true" >> $GITHUB_OUTPUT
                       exit 0
                   fi
 
                   ARTIFACT_NAME="snapshot-v2-$(sed 's/\//-/g' <<< '${{ matrix.testConfig }}')"
-                  echo "::set-output name=name::$ARTIFACT_NAME"
+                  echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
 
                   ARTIFACT_PATH="snapshotsV2/"
-                  echo "::set-output name=filePath::$ARTIFACT_PATH"
+                  echo "filePath=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
 
                   # even though we're not committing files here, this forces git to list full file paths, not folders
                   git add .


### PR DESCRIPTION
Address GitHub Actions deprecation warning of `set-output` command (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)