### PR TITLE
fix: simplify handling of deviceID

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -8,7 +8,8 @@ import {
     createState,
     parseObjFromEncoding,
     getRequestDuration,
-    getTsCookieFromStorage
+    getTsCookieFromStorage,
+    getOrCreateDeviceID
 } from '../../utils';
 
 const Message = function ({ markup, meta, parentStyles, warnings }) {
@@ -164,6 +165,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     stageTag,
                     merchant_config: merchantConfigHash,
                     channel,
+                    deviceID: getOrCreateDeviceID(),
                     treatments: treatmentsHash,
                     disableSetCookie,
                     features

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -73,7 +73,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         meta: serverData.meta,
         activeTags: getActiveTags(button),
         messageRequestId,
-        // Utility will create iframe deviceID/ts_cookie values if it doesn't exist.
+        // Utility will create iframe ts_cookie values if it doesn't exist.
         ts: getTsCookieFromStorage(),
         // getRequestDuration runs in the child component (iframe/banner message),
         // passing a value to onReady and up to the parent component to go out with

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -9,7 +9,7 @@ import {
     parseObjFromEncoding,
     getRequestDuration,
     getTsCookieFromStorage,
-    getOrCreateStorageID
+    getOrCreatedDeviceID
 } from '../../utils';
 
 const Message = function ({ markup, meta, parentStyles, warnings }) {
@@ -76,7 +76,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         messageRequestId,
         // Utility will create iframe deviceID/ts_cookie values if it doesn't exist.
         ts: getTsCookieFromStorage(),
-        deviceID: getOrCreateStorageID(),
+        deviceID: getOrCreatedDeviceID(),
         // getRequestDuration runs in the child component (iframe/banner message),
         // passing a value to onReady and up to the parent component to go out with
         // the other stats
@@ -208,7 +208,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                                 messageRequestId: newMessageRequestId,
                                 // Utility will create iframe ts cookie if it doesn't exist.
                                 ts: getTsCookieFromStorage(),
-                                deviceID: getOrCreateStorageID(),
+                                deviceID: getOrCreatedDeviceID(),
                                 // getRequestDuration runs in the child component (iframe/banner message),
                                 // passing a value to onReady and up to the parent component to go out with
                                 // the other stats

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -8,7 +8,8 @@ import {
     createState,
     parseObjFromEncoding,
     getRequestDuration,
-    getTsCookieFromStorage
+    getTsCookieFromStorage,
+    getOrCreateStorageID
 } from '../../utils';
 
 const Message = function ({ markup, meta, parentStyles, warnings }) {
@@ -75,6 +76,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         messageRequestId,
         // Utility will create iframe deviceID/ts_cookie values if it doesn't exist.
         ts: getTsCookieFromStorage(),
+        deviceID: getOrCreateStorageID(),
         // getRequestDuration runs in the child component (iframe/banner message),
         // passing a value to onReady and up to the parent component to go out with
         // the other stats
@@ -206,6 +208,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                                 messageRequestId: newMessageRequestId,
                                 // Utility will create iframe ts cookie if it doesn't exist.
                                 ts: getTsCookieFromStorage(),
+                                deviceID: getOrCreateStorageID(),
                                 // getRequestDuration runs in the child component (iframe/banner message),
                                 // passing a value to onReady and up to the parent component to go out with
                                 // the other stats

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -6,24 +6,13 @@ import {
     getActiveTags,
     ppDebug,
     createState,
-    isStorageFresh,
-    getDeviceID,
     parseObjFromEncoding,
     getRequestDuration,
     getTsCookieFromStorage
 } from '../../utils';
 
 const Message = function ({ markup, meta, parentStyles, warnings }) {
-    const {
-        onClick,
-        onReady,
-        onHover,
-        onMarkup,
-        onProps,
-        resize,
-        deviceID: parentDeviceID,
-        messageRequestId
-    } = window.xprops;
+    const { onClick, onReady, onHover, onMarkup, onProps, resize, messageRequestId } = window.xprops;
 
     const dimensionsRef = { current: { width: 0, height: 0 } };
 
@@ -85,7 +74,6 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         activeTags: getActiveTags(button),
         messageRequestId,
         // Utility will create iframe deviceID/ts_cookie values if it doesn't exist.
-        deviceID: isStorageFresh() ? parentDeviceID : getDeviceID(),
         ts: getTsCookieFromStorage(),
         // getRequestDuration runs in the child component (iframe/banner message),
         // passing a value to onReady and up to the parent component to go out with
@@ -216,8 +204,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                                 meta: data.meta ?? serverData.meta,
                                 activeTags: getActiveTags(button),
                                 messageRequestId: newMessageRequestId,
-                                // Utility will create iframe deviceID/ts cookie if it doesn't exist.
-                                deviceID: isStorageFresh() ? parentDeviceID : getDeviceID(),
+                                // Utility will create iframe ts cookie if it doesn't exist.
                                 ts: getTsCookieFromStorage(),
                                 // getRequestDuration runs in the child component (iframe/banner message),
                                 // passing a value to onReady and up to the parent component to go out with

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -8,8 +8,7 @@ import {
     createState,
     parseObjFromEncoding,
     getRequestDuration,
-    getTsCookieFromStorage,
-    getOrCreatedDeviceID
+    getTsCookieFromStorage
 } from '../../utils';
 
 const Message = function ({ markup, meta, parentStyles, warnings }) {
@@ -76,7 +75,6 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         messageRequestId,
         // Utility will create iframe deviceID/ts_cookie values if it doesn't exist.
         ts: getTsCookieFromStorage(),
-        deviceID: getOrCreatedDeviceID(),
         // getRequestDuration runs in the child component (iframe/banner message),
         // passing a value to onReady and up to the parent component to go out with
         // the other stats
@@ -208,7 +206,6 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                                 messageRequestId: newMessageRequestId,
                                 // Utility will create iframe ts cookie if it doesn't exist.
                                 ts: getTsCookieFromStorage(),
-                                deviceID: getOrCreatedDeviceID(),
                                 // getRequestDuration runs in the child component (iframe/banner message),
                                 // passing a value to onReady and up to the parent component to go out with
                                 // the other stats

--- a/src/components/modal/parts/Container.jsx
+++ b/src/components/modal/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import { getTsCookieFromStorage } from '../../../utils';
+import { getOrCreateStorageID, getTsCookieFromStorage } from '../../../utils';
 
 import {
     useTransitionState,
@@ -59,6 +59,7 @@ const Container = ({ children, contentWrapper, contentMaxWidth, contentMaxHeight
                 products: productNames,
                 messageRequestId,
                 meta,
+                deviceID: getOrCreateStorageID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/parts/Container.jsx
+++ b/src/components/modal/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import { getOrCreateStorageID, getTsCookieFromStorage } from '../../../utils';
+import { getOrCreatedDeviceID, getTsCookieFromStorage } from '../../../utils';
 
 import {
     useTransitionState,
@@ -59,7 +59,7 @@ const Container = ({ children, contentWrapper, contentMaxWidth, contentMaxHeight
                 products: productNames,
                 messageRequestId,
                 meta,
-                deviceID: getOrCreateStorageID(),
+                deviceID: getOrCreatedDeviceID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/parts/Container.jsx
+++ b/src/components/modal/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import { getOrCreatedDeviceID, getTsCookieFromStorage } from '../../../utils';
+import { getTsCookieFromStorage } from '../../../utils';
 
 import {
     useTransitionState,
@@ -59,7 +59,6 @@ const Container = ({ children, contentWrapper, contentMaxWidth, contentMaxHeight
                 products: productNames,
                 messageRequestId,
                 meta,
-                deviceID: getOrCreatedDeviceID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/parts/Container.jsx
+++ b/src/components/modal/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import { getDeviceID, isStorageFresh, getTsCookieFromStorage } from '../../../utils';
+import { getTsCookieFromStorage } from '../../../utils';
 
 import {
     useTransitionState,
@@ -28,7 +28,6 @@ const Container = ({ children, contentWrapper, contentMaxWidth, contentMaxHeight
         messageRequestId,
         ignoreCache,
         version,
-        deviceID: parentDeviceID,
         stageTag
     } = useXProps();
     const [transitionState] = useTransitionState();
@@ -60,8 +59,6 @@ const Container = ({ children, contentWrapper, contentMaxWidth, contentMaxHeight
                 products: productNames,
                 messageRequestId,
                 meta,
-                // If storage state is brand new, use the parent deviceID/ts cookie, otherwise use child
-                deviceID: isStorageFresh() ? parentDeviceID : getDeviceID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/v2/lib/hooks/calculator.js
+++ b/src/components/modal/v2/lib/hooks/calculator.js
@@ -2,7 +2,6 @@ import { useReducer, useMemo, useRef } from 'preact/hooks';
 import { debounce } from '@krakenjs/belter/src';
 
 import { useXProps, useServerData } from '../providers';
-import { getOrCreatedDeviceID } from '../../../../../utils';
 import { useDidUpdateEffect } from './helpers';
 import { getContent } from '../utils';
 import { localize, delocalize } from '../locale';
@@ -65,6 +64,7 @@ export default function useCalculator({ autoSubmit = false } = {}) {
         integrationType,
         channel,
         ecToken,
+        deviceID,
         devTouchpoint,
         disableSetCookie,
         features
@@ -94,7 +94,7 @@ export default function useCalculator({ autoSubmit = false } = {}) {
             channel,
             ecToken,
             devTouchpoint,
-            deviceID: getOrCreatedDeviceID(),
+            deviceID,
             disableSetCookie,
             features
         })

--- a/src/components/modal/v2/lib/hooks/calculator.js
+++ b/src/components/modal/v2/lib/hooks/calculator.js
@@ -2,7 +2,7 @@ import { useReducer, useMemo, useRef } from 'preact/hooks';
 import { debounce } from '@krakenjs/belter/src';
 
 import { useXProps, useServerData } from '../providers';
-import { getOrCreateStorageID } from '../../../../../utils';
+import { getOrCreatedDeviceID } from '../../../../../utils';
 import { useDidUpdateEffect } from './helpers';
 import { getContent } from '../utils';
 import { localize, delocalize } from '../locale';
@@ -94,7 +94,7 @@ export default function useCalculator({ autoSubmit = false } = {}) {
             channel,
             ecToken,
             devTouchpoint,
-            deviceID: getOrCreateStorageID(),
+            deviceID: getOrCreatedDeviceID(),
             disableSetCookie,
             features
         })

--- a/src/components/modal/v2/lib/hooks/calculator.js
+++ b/src/components/modal/v2/lib/hooks/calculator.js
@@ -5,6 +5,7 @@ import { useXProps, useServerData } from '../providers';
 import { useDidUpdateEffect } from './helpers';
 import { getContent } from '../utils';
 import { localize, delocalize } from '../locale';
+import { getOrCreateDeviceID } from '../../../../../utils';
 
 const reducer = (state, action) => {
     switch (action.type) {
@@ -64,7 +65,6 @@ export default function useCalculator({ autoSubmit = false } = {}) {
         integrationType,
         channel,
         ecToken,
-        deviceID,
         devTouchpoint,
         disableSetCookie,
         features
@@ -94,7 +94,7 @@ export default function useCalculator({ autoSubmit = false } = {}) {
             channel,
             ecToken,
             devTouchpoint,
-            deviceID,
+            deviceID: getOrCreateDeviceID(),
             disableSetCookie,
             features
         })

--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -10,7 +10,7 @@ const setupBrowser = props => {
         // We will never recieve new props via this integration style
         onProps: () => {},
         // TODO: Verify these callbacks are instrumented correctly
-        onReady: ({ products, meta }) => {
+        onReady: ({ products, meta, deviceID }) => {
             const { clientId, payerId, merchantId, offer, partnerAttributionId } = props;
             const { trackingDetails } = meta;
 
@@ -29,9 +29,9 @@ const setupBrowser = props => {
                     global: {
                         ...existingGlobal,
                         // integration_type needs to be sent or it will default to lander
-                        integration_type: props.integrationType ?? __MESSAGES__.__TARGET__
-                        // Device ID is not present for standalone modal integrations made with the presentment API
-                        // deviceID
+                        integration_type: props.integrationType ?? __MESSAGES__.__TARGET__,
+                        // Device ID should be correctly set during message render
+                        deviceID
                         // sessionID: getSessionID()
                     },
                     1: {

--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -1,6 +1,6 @@
 /* global Android */
 import { isAndroidWebview, isIosWebview, getPerformance } from '@krakenjs/belter/src';
-import { getOrCreatedDeviceID, logger } from '../../../../utils';
+import { getOrCreateDeviceID, logger } from '../../../../utils';
 
 const IOS_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
 const ANDROID_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
@@ -31,7 +31,7 @@ const setupBrowser = props => {
                         // integration_type needs to be sent or it will default to lander
                         integration_type: props.integrationType ?? __MESSAGES__.__TARGET__,
                         // Device ID should be correctly set during message render
-                        deviceID: getOrCreatedDeviceID()
+                        deviceID: getOrCreateDeviceID()
                         // sessionID: getSessionID()
                     },
                     1: {

--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -10,7 +10,7 @@ const setupBrowser = props => {
         // We will never recieve new props via this integration style
         onProps: () => {},
         // TODO: Verify these callbacks are instrumented correctly
-        onReady: ({ products, meta, deviceID }) => {
+        onReady: ({ products, meta }) => {
             const { clientId, payerId, merchantId, offer, partnerAttributionId } = props;
             const { trackingDetails } = meta;
 
@@ -29,9 +29,9 @@ const setupBrowser = props => {
                     global: {
                         ...existingGlobal,
                         // integration_type needs to be sent or it will default to lander
-                        integration_type: props.integrationType ?? __MESSAGES__.__TARGET__,
-                        // Device ID should be correctly set during message render
-                        deviceID
+                        integration_type: props.integrationType ?? __MESSAGES__.__TARGET__
+                        // Device ID is not present for standalone modal integrations made with the presentment API
+                        // deviceID
                         // sessionID: getSessionID()
                     },
                     1: {

--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -1,6 +1,6 @@
 /* global Android */
 import { isAndroidWebview, isIosWebview, getPerformance } from '@krakenjs/belter/src';
-import { logger } from '../../../../utils';
+import { getOrCreatedDeviceID, logger } from '../../../../utils';
 
 const IOS_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
 const ANDROID_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
@@ -10,7 +10,7 @@ const setupBrowser = props => {
         // We will never recieve new props via this integration style
         onProps: () => {},
         // TODO: Verify these callbacks are instrumented correctly
-        onReady: ({ products, meta, deviceID }) => {
+        onReady: ({ products, meta }) => {
             const { clientId, payerId, merchantId, offer, partnerAttributionId } = props;
             const { trackingDetails } = meta;
 
@@ -31,7 +31,7 @@ const setupBrowser = props => {
                         // integration_type needs to be sent or it will default to lander
                         integration_type: props.integrationType ?? __MESSAGES__.__TARGET__,
                         // Device ID should be correctly set during message render
-                        deviceID
+                        deviceID: getOrCreatedDeviceID()
                         // sessionID: getSessionID()
                     },
                     1: {

--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -57,7 +57,6 @@ const Container = ({ children }) => {
                     .filter(({ meta: productMeta }) => productMeta?.product)
                     .map(({ meta: productMeta }) => productMeta.product),
                 meta,
-                deviceID,
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
-import { getOrCreateStorageID, getTsCookieFromStorage } from '../../../../utils';
+import { getOrCreatedDeviceID, getTsCookieFromStorage } from '../../../../utils';
 
 import {
     useTransitionState,
@@ -39,7 +39,7 @@ const Container = ({ children }) => {
     } = useXProps();
     const [transitionState] = useTransitionState();
     const [loading, setLoading] = useState(false);
-    const deviceID = getOrCreateStorageID();
+    const deviceID = getOrCreatedDeviceID();
 
     useEffect(() => {
         if (transitionState === 'CLOSED') {
@@ -57,7 +57,7 @@ const Container = ({ children }) => {
                     .filter(({ meta: productMeta }) => productMeta?.product)
                     .map(({ meta: productMeta }) => productMeta.product),
                 meta,
-                deviceID: getOrCreateStorageID(),
+                deviceID: getOrCreatedDeviceID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
-import { getTsCookieFromStorage } from '../../../../utils';
+import { getOrCreateDeviceID, getTsCookieFromStorage } from '../../../../utils';
 
 import {
     useTransitionState,
@@ -34,7 +34,6 @@ const Container = ({ children }) => {
         stageTag,
         channel,
         ecToken,
-        deviceID,
         disableSetCookie,
         features
     } = useXProps();
@@ -78,7 +77,7 @@ const Container = ({ children }) => {
             stageTag,
             channel,
             ecToken,
-            deviceID,
+            deviceID: getOrCreateDeviceID(),
             disableSetCookie,
             features
         }).then(data => {

--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -57,6 +57,7 @@ const Container = ({ children }) => {
                     .filter(({ meta: productMeta }) => productMeta?.product)
                     .map(({ meta: productMeta }) => productMeta.product),
                 meta,
+                deviceID: getOrCreateStorageID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
-import { getOrCreatedDeviceID, getTsCookieFromStorage } from '../../../../utils';
+import { getTsCookieFromStorage } from '../../../../utils';
 
 import {
     useTransitionState,
@@ -34,12 +34,12 @@ const Container = ({ children }) => {
         stageTag,
         channel,
         ecToken,
+        deviceID,
         disableSetCookie,
         features
     } = useXProps();
     const [transitionState] = useTransitionState();
     const [loading, setLoading] = useState(false);
-    const deviceID = getOrCreatedDeviceID();
 
     useEffect(() => {
         if (transitionState === 'CLOSED') {
@@ -57,7 +57,6 @@ const Container = ({ children }) => {
                     .filter(({ meta: productMeta }) => productMeta?.product)
                     .map(({ meta: productMeta }) => productMeta.product),
                 meta,
-                deviceID: getOrCreatedDeviceID(),
                 ts: getTsCookieFromStorage()
             });
         }

--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -17,7 +17,7 @@ import {
     getGlobalState,
     getCurrentTime,
     writeToLocalStorage,
-    getOrCreateStorageID,
+    getOrCreatedDeviceID,
     getStageTag,
     getFeatures,
     getNonce,
@@ -242,8 +242,11 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                 global: {
                                     ...existingGlobal,
                                     ts: tsCookie,
-                                    deviceID: getOrCreateStorageID(), // deviceID from internal iframe storage
-                                    sessionID: getSessionID() // Session ID from parent local storage,
+                                    // deviceID from internal iframe storage
+                                    // should be populated previously by the treatments component
+                                    deviceID: getOrCreatedDeviceID(),
+                                    // Session ID from parent local storage,
+                                    sessionID: getSessionID()
                                 },
                                 [index]: {
                                     type: 'message',
@@ -398,8 +401,8 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
             deviceID: {
                 type: 'string',
                 queryParam: true,
-                value: getOrCreateStorageID,
-                debug: ppDebug(`Device ID: ${getOrCreateStorageID()}`)
+                value: getOrCreatedDeviceID,
+                debug: ppDebug(`Device ID: ${getOrCreatedDeviceID()}`)
             },
             sessionID: {
                 type: 'string',

--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -17,7 +17,7 @@ import {
     getGlobalState,
     getCurrentTime,
     writeToLocalStorage,
-    getOrCreatedDeviceID,
+    getOrCreateDeviceID,
     getStageTag,
     getFeatures,
     getNonce,
@@ -244,7 +244,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                     ts: tsCookie,
                                     // deviceID from internal iframe storage
                                     // should be populated previously by the treatments component
-                                    deviceID: getOrCreatedDeviceID(),
+                                    deviceID: getOrCreateDeviceID(),
                                     // Session ID from parent local storage,
                                     sessionID: getSessionID()
                                 },
@@ -401,8 +401,8 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
             deviceID: {
                 type: 'string',
                 queryParam: true,
-                value: getOrCreatedDeviceID,
-                debug: ppDebug(`Device ID: ${getOrCreatedDeviceID()}`)
+                value: getOrCreateDeviceID,
+                debug: ppDebug(`Device ID: ${getOrCreateDeviceID()}`)
             },
             sessionID: {
                 type: 'string',

--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -212,7 +212,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                 queryParam: false,
                 value: ({ props }) => {
                     const { onReady } = props;
-                    return ({ meta, activeTags, deviceID, ts, requestDuration, messageRequestId }) => {
+                    return ({ meta, activeTags, ts, requestDuration, messageRequestId }) => {
                         const { account, merchantId, index, modal, getContainer } = props;
                         const { trackingDetails, offerType, ppDebugId } = meta;
                         const partnerClientId = merchantId && account.slice(10); // slice is to remove the characters 'client-id:' from account name
@@ -224,7 +224,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                         // We still want to write it here to handle the scenario where the SDK has never been loaded
                         // and thus the inner iframe has no value for deviceID until after the first message render
                         const tsCookie = typeof ts !== 'undefined' ? ts : getTsCookieFromStorage();
-                        writeToLocalStorage({ id: deviceID, ts: tsCookie });
+                        writeToLocalStorage({ ts: tsCookie });
 
                         logger.addMetaBuilder(existingMeta => {
                             // Remove potential existing meta info
@@ -242,7 +242,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                 global: {
                                     ...existingGlobal,
                                     ts: tsCookie,
-                                    deviceID, // deviceID from internal iframe storage
+                                    deviceID: getOrCreateStorageID(), // deviceID from internal iframe storage
                                     sessionID: getSessionID() // Session ID from parent local storage,
                                 },
                                 [index]: {

--- a/src/library/zoid/modal/component.js
+++ b/src/library/zoid/modal/component.js
@@ -17,7 +17,7 @@ import {
     nextIndex,
     getPerformanceMeasure,
     getSessionID,
-    getDeviceID,
+    getOrCreateStorageID,
     getStageTag,
     getFeatures,
     getNonce,
@@ -243,7 +243,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                 value: ({ props, state, event }) => {
                     const { onReady } = props;
                     // Fired anytime we fetch new content (e.g. amount change)
-                    return ({ products, meta, ts, deviceID }) => {
+                    return ({ products, meta, ts }) => {
                         const { index, offer, merchantId, account, refIndex, messageRequestId } = props;
                         const { renderStart, show, hide } = state;
                         const { trackingDetails, ppDebugId } = meta;
@@ -269,7 +269,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                                     ...existingGlobal,
                                     ts: tsCookie,
                                     // Device ID should be correctly set during message render
-                                    deviceID,
+                                    deviceID: getOrCreateStorageID(),
                                     sessionID: getSessionID()
                                 },
                                 [index]: {
@@ -368,7 +368,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
             deviceID: {
                 type: 'string',
                 queryParam: true,
-                value: getDeviceID
+                value: getOrCreateStorageID
             },
             sessionID: {
                 type: 'string',

--- a/src/library/zoid/modal/component.js
+++ b/src/library/zoid/modal/component.js
@@ -17,7 +17,7 @@ import {
     nextIndex,
     getPerformanceMeasure,
     getSessionID,
-    getOrCreateStorageID,
+    getOrCreatedDeviceID,
     getStageTag,
     getFeatures,
     getNonce,
@@ -269,7 +269,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                                     ...existingGlobal,
                                     ts: tsCookie,
                                     // Device ID should be correctly set during message render
-                                    deviceID: getOrCreateStorageID(),
+                                    deviceID: getOrCreatedDeviceID(),
                                     sessionID: getSessionID()
                                 },
                                 [index]: {
@@ -368,7 +368,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
             deviceID: {
                 type: 'string',
                 queryParam: true,
-                value: getOrCreateStorageID
+                value: getOrCreatedDeviceID
             },
             sessionID: {
                 type: 'string',

--- a/src/library/zoid/modal/component.js
+++ b/src/library/zoid/modal/component.js
@@ -17,7 +17,7 @@ import {
     nextIndex,
     getPerformanceMeasure,
     getSessionID,
-    getOrCreatedDeviceID,
+    getOrCreateDeviceID,
     getStageTag,
     getFeatures,
     getNonce,
@@ -269,7 +269,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                                     ...existingGlobal,
                                     ts: tsCookie,
                                     // Device ID should be correctly set during message render
-                                    deviceID: getOrCreatedDeviceID(),
+                                    deviceID: getOrCreateDeviceID(),
                                     sessionID: getSessionID()
                                 },
                                 [index]: {
@@ -368,7 +368,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
             deviceID: {
                 type: 'string',
                 queryParam: true,
-                value: getOrCreatedDeviceID
+                value: getOrCreateDeviceID
             },
             sessionID: {
                 type: 'string',

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -74,9 +74,12 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                         writeToLocalStorage({
                             experiments: {
                                 treatmentsHash,
-                                // Experiments can only be maintained for 24 hours
+                                // Experiments can only be maintained for 15 minutes
                                 expiration: Date.now() + TREATMENTS_MAX_AGE
                             },
+                            // Write deviceID from paypal.com localStorage to merchant domain localStorage
+                            // This should be the only place that we write to the storage.id
+                            // to prevent it getting out of sync with treatmentsHash
                             id: deviceID
                         });
 

--- a/src/utils/experiments.js
+++ b/src/utils/experiments.js
@@ -38,8 +38,6 @@ export function getLocalTreatments() {
 
 export function ensureTreatments() {
     if (
-        // non-sdk integrations do not support edge caching and therefore, do not need treatmentsHash
-        __MESSAGES__.__TARGET__ !== 'SDK' ||
         // we already have local treatments
         getLocalTreatments() ||
         // we can't get local treatments if local storage is not supported (this should be extremely rare)

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -177,12 +177,6 @@ export function writeToLocalStorage(values) {
         : {};
 }
 
-// Use the custom deviceID field, but fall back to storage ID if it is not yet present
-// or does not exist (as in the child )
-export function getDeviceID() {
-    return getStorage().getState(storage => storage.messagingDeviceID ?? storage.id);
-}
-
 // Check if the current script is in the process of being destroyed since
 // the MutationObservers can fire before the SDK destroy lifecycle hook
 export const isScriptBeingDestroyed = () => {

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -146,7 +146,7 @@ export function getSessionID() {
 }
 
 // Retrieves storageID. NOTE: Creates new ID if not already in local storage.
-export function getOrCreatedDeviceID() {
+export function getOrCreateDeviceID() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         return getSDKStorageID();
     } else {

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -146,7 +146,7 @@ export function getSessionID() {
 }
 
 // Retrieves storageID. NOTE: Creates new ID if not already in local storage.
-export function getOrCreateStorageID() {
+export function getOrCreatedDeviceID() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         return getSDKStorageID();
     } else {

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -154,10 +154,6 @@ export function getOrCreateStorageID() {
     }
 }
 
-export function isStorageFresh() {
-    return getStorage().isStateFresh();
-}
-
 // Retrieve namespaced localStorage directly
 function getRawStorage() {
     return isLocalStorageEnabled()

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -12,6 +12,7 @@ jest.mock('src/utils', () => ({
     createState: jest.fn(obj => [obj, jest.fn()]),
     getActiveTags: jest.fn(),
     getTsCookieFromStorage: jest.fn(() => ts),
+    getOrCreateDeviceID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
     request: jest.fn(() =>
         Promise.resolve({
             data: '<!--ewAiAG0AYQByAGsAdQBwACIAOgAiADwAZABpAHYAPgBtAG8AYwBrADwALwBkAGkAdgA+ACIALAAiAG0AZQB0AGEAIgA6AHsAIgBtAGUAcwBzAGEAZwBlAFIAZQBxAHUAZQBzAHQASQBkACIAOgAiADIAMwA0ADUANgAiAH0ALAAiAHAAYQByAGUAbgB0AFMAdAB5AGwAZQBzACIAOgAiAGIAbwBkAHkAIAB7ACAAYwBvAGwAbwByADoAIABiAGwAdQBlADsAIAB9ACIALAAiAHcAYQByAG4AaQBuAGcAcwAiADoAWwBdAH0A-->'

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -1,7 +1,7 @@
 import { getByText, fireEvent, queryByText } from '@testing-library/dom';
 
 import Message from 'src/components/message/Message';
-import { request, getOrCreateStorageID, createState } from 'src/utils';
+import { request, getOrCreatedDeviceID, createState } from 'src/utils';
 import xPropsMock from 'utils/xPropsMock';
 
 const ts = {
@@ -11,7 +11,7 @@ const ts = {
 jest.mock('src/utils', () => ({
     createState: jest.fn(obj => [obj, jest.fn()]),
     getActiveTags: jest.fn(),
-    getOrCreateStorageID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
+    getOrCreatedDeviceID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
     getTsCookieFromStorage: jest.fn(() => ts),
     request: jest.fn(() =>
         Promise.resolve({
@@ -62,7 +62,7 @@ describe('Message', () => {
 
         createState.mockClear();
         request.mockClear();
-        getOrCreateStorageID.mockClear();
+        getOrCreatedDeviceID.mockClear();
         xPropsMock.clear();
     });
 
@@ -93,8 +93,8 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
-            requestDuration: 123,
             deviceID: 'uid_26a2522628_mtc6mjk6nti',
+            requestDuration: 123,
             ts
         });
     });
@@ -132,8 +132,8 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: originalMRID,
-            requestDuration: 123,
             deviceID: 'uid_26a2522628_mtc6mjk6nti',
+            requestDuration: 123,
             ts
         });
 
@@ -160,8 +160,8 @@ describe('Message', () => {
                 messageRequestId: '23456'
             },
             messageRequestId: expect.not.stringMatching(originalMRID),
-            requestDuration: 123,
             deviceID: 'uid_26a2522628_mtc6mjk6nti',
+            requestDuration: 123,
             ts
         });
         expect(window.xprops.onMarkup).toHaveBeenLastCalledWith({
@@ -174,15 +174,15 @@ describe('Message', () => {
     });
 
     test('Passed deviceID from iframe storage to callback', () => {
-        getOrCreateStorageID.mockReturnValue('uid_1111111111_11111111111');
+        getOrCreatedDeviceID.mockReturnValue('uid_1111111111_11111111111');
 
         Message(serverData);
 
         expect(window.xprops.onReady).toBeCalledWith({
             meta: {},
+            deviceID: 'uid_1111111111_11111111111',
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
             requestDuration: 123,
-            deviceID: 'uid_1111111111_11111111111',
             ts
         });
     });

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -12,7 +12,6 @@ jest.mock('src/utils', () => ({
     createState: jest.fn(obj => [obj, jest.fn()]),
     getActiveTags: jest.fn(),
     getOrCreateStorageID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
-    isStorageFresh: jest.fn().mockReturnValue(false),
     getTsCookieFromStorage: jest.fn(() => ts),
     request: jest.fn(() =>
         Promise.resolve({

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -1,7 +1,7 @@
 import { getByText, fireEvent, queryByText } from '@testing-library/dom';
 
 import Message from 'src/components/message/Message';
-import { request, getDeviceID, createState } from 'src/utils';
+import { request, getOrCreateStorageID, createState } from 'src/utils';
 import xPropsMock from 'utils/xPropsMock';
 
 const ts = {
@@ -11,7 +11,7 @@ const ts = {
 jest.mock('src/utils', () => ({
     createState: jest.fn(obj => [obj, jest.fn()]),
     getActiveTags: jest.fn(),
-    getDeviceID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
+    getOrCreateStorageID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
     isStorageFresh: jest.fn().mockReturnValue(false),
     getTsCookieFromStorage: jest.fn(() => ts),
     request: jest.fn(() =>
@@ -63,7 +63,7 @@ describe('Message', () => {
 
         createState.mockClear();
         request.mockClear();
-        getDeviceID.mockClear();
+        getOrCreateStorageID.mockClear();
         xPropsMock.clear();
     });
 
@@ -94,7 +94,6 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -133,7 +132,6 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: originalMRID,
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -161,7 +159,6 @@ describe('Message', () => {
                 messageRequestId: '23456'
             },
             messageRequestId: expect.not.stringMatching(originalMRID),
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -175,17 +172,15 @@ describe('Message', () => {
     });
 
     test('Passed deviceID from iframe storage to callback', () => {
-        getDeviceID.mockReturnValue('uid_1111111111_11111111111');
+        getOrCreateStorageID.mockReturnValue('uid_1111111111_11111111111');
 
         Message(serverData);
 
         expect(window.xprops.onReady).toBeCalledWith({
             meta: {},
-            deviceID: 'uid_1111111111_11111111111',
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
             requestDuration: 123,
             ts
         });
-        expect(getDeviceID).toHaveBeenCalled();
     });
 });

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -95,6 +95,7 @@ describe('Message', () => {
             meta: {},
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
             requestDuration: 123,
+            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             ts
         });
     });
@@ -133,6 +134,7 @@ describe('Message', () => {
             meta: {},
             messageRequestId: originalMRID,
             requestDuration: 123,
+            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             ts
         });
 
@@ -160,6 +162,7 @@ describe('Message', () => {
             },
             messageRequestId: expect.not.stringMatching(originalMRID),
             requestDuration: 123,
+            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             ts
         });
         expect(window.xprops.onMarkup).toHaveBeenLastCalledWith({
@@ -180,6 +183,7 @@ describe('Message', () => {
             meta: {},
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
             requestDuration: 123,
+            deviceID: 'uid_1111111111_11111111111',
             ts
         });
     });

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -1,7 +1,7 @@
 import { getByText, fireEvent, queryByText } from '@testing-library/dom';
 
 import Message from 'src/components/message/Message';
-import { request, getOrCreatedDeviceID, createState } from 'src/utils';
+import { request, createState } from 'src/utils';
 import xPropsMock from 'utils/xPropsMock';
 
 const ts = {
@@ -11,7 +11,6 @@ const ts = {
 jest.mock('src/utils', () => ({
     createState: jest.fn(obj => [obj, jest.fn()]),
     getActiveTags: jest.fn(),
-    getOrCreatedDeviceID: jest.fn(() => 'uid_26a2522628_mtc6mjk6nti'),
     getTsCookieFromStorage: jest.fn(() => ts),
     request: jest.fn(() =>
         Promise.resolve({
@@ -62,7 +61,6 @@ describe('Message', () => {
 
         createState.mockClear();
         request.mockClear();
-        getOrCreatedDeviceID.mockClear();
         xPropsMock.clear();
     });
 
@@ -93,7 +91,6 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -132,7 +129,6 @@ describe('Message', () => {
         expect(window.xprops.onReady).toHaveBeenLastCalledWith({
             meta: {},
             messageRequestId: originalMRID,
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -160,7 +156,6 @@ describe('Message', () => {
                 messageRequestId: '23456'
             },
             messageRequestId: expect.not.stringMatching(originalMRID),
-            deviceID: 'uid_26a2522628_mtc6mjk6nti',
             requestDuration: 123,
             ts
         });
@@ -174,13 +169,10 @@ describe('Message', () => {
     });
 
     test('Passed deviceID from iframe storage to callback', () => {
-        getOrCreatedDeviceID.mockReturnValue('uid_1111111111_11111111111');
-
         Message(serverData);
 
         expect(window.xprops.onReady).toBeCalledWith({
             meta: {},
-            deviceID: 'uid_1111111111_11111111111',
             messageRequestId: 'uid_xxxxxxxxxx_xxxxxxxxxxx',
             requestDuration: 123,
             ts

--- a/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
+++ b/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
@@ -93,7 +93,6 @@ describe('zoidPollyfill', () => {
 
         window.xprops.onReady({
             products: ['PRODUCT_1', 'PRODUCT_2'],
-            deviceID: 'abc123',
             meta: { trackingDetails: 'trackingDetails' }
         });
 
@@ -188,7 +187,6 @@ describe('zoidPollyfill', () => {
 
         window.xprops.onReady({
             products: ['PRODUCT_1', 'PRODUCT_2'],
-            deviceID: 'abc123',
             meta: {
                 trackingDetails: {
                     fdata: '123abc',
@@ -346,7 +344,6 @@ describe('zoidPollyfill', () => {
 
         window.xprops.onReady({
             products: ['PRODUCT_1', 'PRODUCT_2'],
-            deviceID: 'abc123',
             meta: {
                 trackingDetails: {
                     fdata: '123abc',

--- a/tests/unit/spec/src/utils/experiments.test.js
+++ b/tests/unit/spec/src/utils/experiments.test.js
@@ -72,8 +72,7 @@ describe('experiments utils', () => {
 
         ensureTreatments();
 
-        expect(document.querySelector('iframe')).toBeNull();
-        expect(globalEvent.trigger).toHaveBeenCalledWith('treatments');
+        expect(document.querySelector('iframe')).not.toBeNull();
 
         window.__MESSAGES__.__TARGET__ = 'SDK';
     });


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->
- Centralizes the handling of deviceID to prevent mismatch between deviceID and treatmentsHash, which is dependent on deviceID
- Enables the treatments component on non-SDK integrations, so deviceID can be populated for those integrations in a common way

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->
N/A

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
Need to consider all possible states of deviceID in localStorage and different integrations that may be currently relying on the way that has been populated previously
