### PR TITLE
feat: updated input on calculator for better accessibility

### DIFF
--- a/src/components/modal/content/DE-GPL/parts/Calculator.jsx
+++ b/src/components/modal/content/DE-GPL/parts/Calculator.jsx
@@ -111,7 +111,6 @@ const Calculator = () => {
                 <div className="input__wrapper transitional">
                     <div className="input__label">{inputLabel}</div>
                     <input
-                        aria-required="true"
                         className="input"
                         type="text"
                         value={displayValue}

--- a/src/components/modal/content/DE-GPL/parts/Calculator.jsx
+++ b/src/components/modal/content/DE-GPL/parts/Calculator.jsx
@@ -110,7 +110,16 @@ const Calculator = () => {
                 {emptyState ? <h3 className="title">{title}</h3> : null}
                 <div className="input__wrapper transitional">
                     <div className="input__label">{inputLabel}</div>
-                    <input className="input" type="tel" value={displayValue} onInput={onInput} onKeyDown={onKeyDown} />
+                    <input
+                        className="input"
+                        type="text"
+                        value={displayValue}
+                        onInput={onInput}
+                        onKeyDown={onKeyDown}
+                        inputmode="tel"
+                        aria-required="true"
+                        pattern="\d*"
+                    />
                 </div>
                 <div
                     className={`content-column transitional calculator__error ${

--- a/src/components/modal/content/DE-GPL/parts/Calculator.jsx
+++ b/src/components/modal/content/DE-GPL/parts/Calculator.jsx
@@ -111,14 +111,13 @@ const Calculator = () => {
                 <div className="input__wrapper transitional">
                     <div className="input__label">{inputLabel}</div>
                     <input
+                        aria-required="true"
                         className="input"
                         type="text"
                         value={displayValue}
                         onInput={onInput}
                         onKeyDown={onKeyDown}
                         inputmode="tel"
-                        aria-required="true"
-                        pattern="\d*"
                     />
                 </div>
                 <div

--- a/src/components/modal/content/DE-GPL/parts/Calculator.jsx
+++ b/src/components/modal/content/DE-GPL/parts/Calculator.jsx
@@ -110,14 +110,7 @@ const Calculator = () => {
                 {emptyState ? <h3 className="title">{title}</h3> : null}
                 <div className="input__wrapper transitional">
                     <div className="input__label">{inputLabel}</div>
-                    <input
-                        className="input"
-                        type="text"
-                        value={displayValue}
-                        onInput={onInput}
-                        onKeyDown={onKeyDown}
-                        inputmode="tel"
-                    />
+                    <input className="input" type="tel" value={displayValue} onInput={onInput} onKeyDown={onKeyDown} />
                 </div>
                 <div
                     className={`content-column transitional calculator__error ${

--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -180,13 +180,15 @@ const Calculator = ({ setExpandedState, calculator, aprDisclaimer }) => {
                     <div className={`input__label ${country}`}>{renderInputLabelOnEmptyField(country)}</div>
                     {inputCurrencySymbol && <div className="input__currency-symbol">{inputCurrencySymbol}</div>}
                     <input
-                        aria-required="true"
                         className={`input ${displayValue === '' && country === 'US' ? 'empty-input' : ''}`}
                         placeholder={currencyFormat(inputPlaceholder).replace(/(\s?€)/g, '')}
-                        type="tel"
+                        type="text"
                         value={displayValue}
                         onInput={onInput}
                         onKeyDown={onKeyDown}
+                        inputmode="tel"
+                        aria-required="true"
+                        pattern="\d*"
                     />
                 </div>
                 <div aria-live="polite">{renderError(error || emptyState || isLoading)}</div>

--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -180,6 +180,7 @@ const Calculator = ({ setExpandedState, calculator, aprDisclaimer }) => {
                     <div className={`input__label ${country}`}>{renderInputLabelOnEmptyField(country)}</div>
                     {inputCurrencySymbol && <div className="input__currency-symbol">{inputCurrencySymbol}</div>}
                     <input
+                        aria-required="true"
                         className={`input ${displayValue === '' && country === 'US' ? 'empty-input' : ''}`}
                         placeholder={currencyFormat(inputPlaceholder).replace(/(\s?€)/g, '')}
                         type="text"
@@ -187,8 +188,6 @@ const Calculator = ({ setExpandedState, calculator, aprDisclaimer }) => {
                         onInput={onInput}
                         onKeyDown={onKeyDown}
                         inputmode="tel"
-                        aria-required="true"
-                        pattern="\d*"
                     />
                 </div>
                 <div aria-live="polite">{renderError(error || emptyState || isLoading)}</div>


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->

The screen readers read the correct input types and doesn't read the calculator's input as type "telephone" but still ensures the numerical keyboard comes up on mobile 

## Screenshots


<img width="657" alt="enteramount" src="https://github.com/paypal/paypal-messaging-components/assets/141269770/7b7f757b-0945-4dc5-8202-ec6d1f67e48b">

![Screenshot 2023-09-14 at 11 06 18 AM](https://github.com/paypal/paypal-messaging-components/assets/141269770/ab7bc7f9-56eb-4516-b926-9438876b17ae)


