### PR TITLE
refactor: enable passing multiple merchant ids

### DIFF
--- a/src/library/zoid/message/validation.js
+++ b/src/library/zoid/message/validation.js
@@ -68,15 +68,22 @@ export default {
     },
     merchantId: ({ props: { merchantId } }) => {
         if (typeof merchantId !== 'undefined') {
+            let invalidId;
             if (!validateType(Types.STRING, merchantId)) {
+                console.log('not a string');
                 logInvalidType('merchantId', Types.STRING, merchantId);
-            } else if (merchantId.length !== 13 && merchantId.length !== 10) {
-                logInvalid('merchantId', 'Ensure the correct Merchant ID has been entered.');
-            } else {
-                return merchantId;
+                invalidId = merchantId;
             }
+            const ids = merchantId.toString().split(',');
+            ids.forEach(id => {
+                console.log('id', typeof id, id.length, id);
+                if (id.length !== 13 && id.length !== 10) {
+                    logInvalid('merchantId', 'Ensure the correct Merchant ID has been entered.');
+                    invalidId = id;
+                }
+            });
+            return invalidId ? undefined : merchantId;
         }
-
         return undefined;
     },
     customerId: ({ props: { customerId } }) => {

--- a/src/library/zoid/message/validation.js
+++ b/src/library/zoid/message/validation.js
@@ -68,19 +68,16 @@ export default {
     },
     merchantId: ({ props: { merchantId } }) => {
         if (typeof merchantId !== 'undefined') {
-            let invalidId;
             if (!validateType(Types.STRING, merchantId)) {
                 logInvalidType('merchantId', Types.STRING, merchantId);
-                invalidId = merchantId;
-            }
-            const ids = merchantId.toString().split(',');
-            ids.forEach(id => {
-                if (id.length !== 13 && id.length !== 10) {
+            } else {
+                const isInvalid = merchantId.split(',').some(id => id.length !== 13 && id.length !== 10);
+                if (isInvalid) {
                     logInvalid('merchantId', 'Ensure the correct Merchant ID has been entered.');
-                    invalidId = id;
+                } else {
+                    return merchantId;
                 }
-            });
-            return invalidId ? undefined : merchantId;
+            }
         }
         return undefined;
     },

--- a/src/library/zoid/message/validation.js
+++ b/src/library/zoid/message/validation.js
@@ -74,9 +74,8 @@ export default {
                 const isInvalid = merchantId.split(',').some(id => id.length !== 13 && id.length !== 10);
                 if (isInvalid) {
                     logInvalid('merchantId', 'Ensure the correct Merchant ID has been entered.');
-                } else {
-                    return merchantId;
                 }
+                return merchantId;
             }
         }
         return undefined;

--- a/src/library/zoid/message/validation.js
+++ b/src/library/zoid/message/validation.js
@@ -70,13 +70,11 @@ export default {
         if (typeof merchantId !== 'undefined') {
             let invalidId;
             if (!validateType(Types.STRING, merchantId)) {
-                console.log('not a string');
                 logInvalidType('merchantId', Types.STRING, merchantId);
                 invalidId = merchantId;
             }
             const ids = merchantId.toString().split(',');
             ids.forEach(id => {
-                console.log('id', typeof id, id.length, id);
                 if (id.length !== 13 && id.length !== 10) {
                     logInvalid('merchantId', 'Ensure the correct Merchant ID has been entered.');
                     invalidId = id;

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -55,7 +55,7 @@ export function getMerchantConfig() {
 export function getAccount() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         // TODO: Should we pass both up if they exist so that nodeweb can create a partner context?
-        return getMerchantID()[0] || `client-id:${getClientID()}`;
+        return getMerchantID().join(',') || `client-id:${getClientID()}`;
     } else {
         return undefined;
     }

--- a/tests/unit/spec/src/zoid/message/validation.test.js
+++ b/tests/unit/spec/src/zoid/message/validation.test.js
@@ -62,7 +62,7 @@ describe('validate', () => {
 
         merchantId = validate.merchantId({ props: { merchantId: 'DEV00000000,DEV00000001NI' } });
 
-        expect(merchantId).toBeUndefined();
+        expect(merchantId).toEqual(merchantId);
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenLastCalledWith(
             expect.stringContaining('invalid_option_value'),
@@ -71,7 +71,7 @@ describe('validate', () => {
 
         merchantId = validate.merchantId({ props: { merchantId: 'client-id:test_client_id' } });
 
-        expect(merchantId).toBeUndefined();
+        expect(merchantId).toEqual(merchantId);
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenLastCalledWith(
             expect.stringContaining('invalid_option_value'),

--- a/tests/unit/spec/src/zoid/message/validation.test.js
+++ b/tests/unit/spec/src/zoid/message/validation.test.js
@@ -56,6 +56,19 @@ describe('validate', () => {
         expect(merchantId).toEqual(merchantId);
         expect(console.warn).not.toHaveBeenCalled();
 
+        merchantId = validate.merchantId({ props: { merchantId: 'DEV00000000NI,DEV00000001NI' } });
+        expect(merchantId).toEqual(merchantId);
+        expect(console.warn).not.toHaveBeenCalled();
+
+        merchantId = validate.merchantId({ props: { merchantId: 'DEV00000000,DEV00000001NI' } });
+
+        expect(merchantId).toBeUndefined();
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenLastCalledWith(
+            expect.stringContaining('invalid_option_value'),
+            expect.objectContaining({ location: 'merchantId' })
+        );
+
         merchantId = validate.merchantId({ props: { merchantId: 'client-id:test_client_id' } });
 
         expect(merchantId).toBeUndefined();


### PR DESCRIPTION
## Description
enable passing multiple merchant ids to cpnw.
 
## Screenshots
N/A

## Testing instructions
valid merchant ids of 10 or 13 characters should pass when inputted as merchant-id=* and data-merchant-id='id1, id2'. otherwise an appropriate error message will appear in the console.log.