### PR TITLE
fix: prevent undefined device ID when namespace

### DIFF
--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -17,7 +17,7 @@ import {
     getSessionID,
     getGlobalState,
     getCurrentTime,
-    writeToLocalStorage,
+    updateStorage,
     getOrCreateDeviceID,
     getStageTag,
     getFeatures,
@@ -225,7 +225,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                         // We still want to write it here to handle the scenario where the SDK has never been loaded
                         // and thus the inner iframe has no value for deviceID until after the first message render
                         const tsCookie = typeof ts !== 'undefined' ? ts : getTsCookieFromStorage();
-                        writeToLocalStorage({ ts: tsCookie });
+                        updateStorage({ ts: tsCookie });
 
                         logger.addMetaBuilder(existingMeta => {
                             // Remove potential existing meta info

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -10,7 +10,7 @@ import {
     getEnv,
     getLibraryVersion,
     getStageTag,
-    writeToLocalStorage,
+    updateStorage,
     getDisableSetCookie,
     getFeatures,
     getDefaultNamespace
@@ -72,7 +72,7 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                     const TREATMENTS_MAX_AGE = 1000 * 60 * 15;
 
                     return ({ treatmentsHash, deviceID }) => {
-                        writeToLocalStorage({
+                        updateStorage({
                             experiments: {
                                 treatmentsHash,
                                 // Experiments can only be maintained for 15 minutes

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -10,10 +10,10 @@ import {
     getEnv,
     getLibraryVersion,
     getStageTag,
-    getNamespace,
     writeToLocalStorage,
     getDisableSetCookie,
-    getFeatures
+    getFeatures,
+    getDefaultNamespace
 } from '../../../utils/sdk';
 import { getGlobalUrl, createGlobalVariableGetter, globalEvent } from '../../../utils/global';
 import { ppDebug } from '../../../utils/debug';
@@ -61,7 +61,7 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
             namespace: {
                 type: 'string',
                 queryParam: false,
-                value: getNamespace
+                value: getDefaultNamespace
             },
 
             onReady: {

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,7 +1,7 @@
 /* eslint-disable eslint-comments/disable-enable-pair, no-else-return */
 import arrayFrom from 'core-js-pure/stable/array/from';
 
-import { isLocalStorageEnabled, getStorage as getBelterStorage } from '@krakenjs/belter/src';
+import { getStorage as getBelterStorage } from '@krakenjs/belter/src';
 import { SDK_QUERY_KEYS, SDK_SETTINGS } from '@paypal/sdk-constants/src';
 import {
     getClientID,
@@ -14,8 +14,10 @@ import {
     getSDKQueryParam,
     getCSPNonce,
     getNamespace as getSDKNamespace,
+    getDefaultNamespace as getDefaultSDKNamespace,
     getSessionID as getSDKSessionID,
     getStorageID as getSDKStorageID,
+    getStorageState as getSDKStorageState,
     getPayPalDomain as getSDKPayPalDomain,
     getDisableSetCookie as getSDKDisableCookie
 } from '@paypal/sdk-client/src';
@@ -116,11 +118,19 @@ export function getScriptAttributes() {
     }
 }
 
+export function getDefaultNamespace() {
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        return getDefaultSDKNamespace();
+    } else {
+        return 'paypal';
+    }
+}
+
 export function getNamespace() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         return getSDKNamespace();
     } else {
-        return getScript()?.getAttribute('data-pp-namespace') || 'paypal';
+        return getScript()?.getAttribute('data-pp-namespace') || getDefaultNamespace();
     }
 }
 
@@ -157,23 +167,12 @@ export function getOrCreateDeviceID() {
     }
 }
 
-// Retrieve namespaced localStorage directly
-function getRawStorage() {
-    return isLocalStorageEnabled()
-        ? JSON.parse(window.localStorage?.getItem(`__${getNamespace()}_storage__`) ?? '{}')
-        : {};
-}
-
 export function writeToLocalStorage(values) {
-    return isLocalStorageEnabled()
-        ? window.localStorage?.setItem(
-              `__${getNamespace()}_storage__`,
-              JSON.stringify({
-                  ...getRawStorage(),
-                  ...values
-              }) ?? '{}'
-          )
-        : {};
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        return getSDKStorageState(storage => Object.assign(storage, values));
+    } else {
+        return getStorage().getState(storage => Object.assign(storage, values));
+    }
 }
 
 // Check if the current script is in the process of being destroyed since

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -167,7 +167,7 @@ export function getOrCreateDeviceID() {
     }
 }
 
-export function writeToLocalStorage(values) {
+export function updateStorage(values) {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
         return getSDKStorageState(storage => Object.assign(storage, values));
     } else {

--- a/tests/unit/spec/src/utils/experiments.test.js
+++ b/tests/unit/spec/src/utils/experiments.test.js
@@ -25,7 +25,8 @@ jest.mock('@paypal/sdk-client/src', () => ({
     getPayPalDomain: () => 'localhost.paypal.com',
     getSDKMeta: () => 'meta',
     getEnv: () => 'local',
-    getDisableSetCookie: () => 'true'
+    getDisableSetCookie: () => 'true',
+    getDefaultNamespace: () => 'paypal'
 }));
 
 describe('experiments utils', () => {


### PR DESCRIPTION
## Description

These changes include 2 fixes
1. When using the SDK namespace feature, currently that results in `"undefined"` being passed up to the experiments endpoint because the SDK instance running inside the IFrame does not get passed the custom namespace and will always use the default namespace. To fix this issue we pass the default namespace into the IFrame to be used instead.
2. @danzhaas noticed that under certain circumstances that different device IDs could be sent to different endpoints for the same message instance. We were unable to reproduce this issue consistently so we have theoretical changes that enforce all local storage reading and writing to go through the common `belter` storage helper to ensure that the `belter` storage instance used by the SDK does not get out of sync with our manual mutations of local storage directly.

## Screenshots

N/A

## Testing instructions

N/A
