### PR TITLE
feat: fix au flex layout spacing

### DIFF
--- a/src/server/locale/AU/mutations/gplq.js
+++ b/src/server/locale/AU/mutations/gplq.js
@@ -50,8 +50,7 @@ const flex = [
             ],
             styles: [
                 '.message__headline .tag--medium > span:first-child > span:last-child:after { content: "."; }',
-                '.message__headline .tag--medium .weak { display: none; }',
-                '@media (min-aspect-ratio: 80/11) and (min-width: 501px) { .message__disclaimer { margin-left: 0; } }'
+                '.message__headline .tag--medium .weak { display: none; }'
             ]
         }
     ],


### PR DESCRIPTION
## Description
Update spacing for AU Pay in 4 8x1 flex banner for qualifying amounts so that there is a space between period after amount(s) and before 'Learn more' link.

## Screenshots
<img width="787" alt="Screenshot 2023-10-25 at 1 05 27 PM" src="https://github.com/paypal/paypal-messaging-components/assets/71471412/b6e00244-4eef-4b41-bb76-a4e291265a0a">

## Testing instructions
TBD