### PR TITLE
fix: adds screenreader visual focus on donut text

### DIFF
--- a/src/components/modal/v2/parts/Donut.jsx
+++ b/src/components/modal/v2/parts/Donut.jsx
@@ -55,15 +55,16 @@ const Donut = ({
                     {isQualifying}
                 </text>
             </svg>
-            {/* Required to read the payment and date details together. Spans and linebreaks cause a pause when stepping */}
-            {/* through the content. Using a p tag instead of span to cause pause in Windows */}
-            <p className="sr-only">
-                {/* Space required between periodicPayment and the comma to read the monetary value correctly */}
-                {isQualifying && periodicPayment !== '-' ? `${periodicPayment} , ${timeStamp}` : timeStamp}
-            </p>
-            <span aria-hidden="true">
-                {isQualifying && periodicPayment !== '-' && <span className="donut__payment">{periodicPayment}</span>}
-                <span className="donut__timestamp">{timeStamp}</span>
+            {/* eslint-disable-next-line jsx-a11y/aria-role */}
+            <span aria-labelledby={`donut__payment__${currentNum} donut__timestamp__${currentNum}`} role="text">
+                {isQualifying && periodicPayment !== '-' && (
+                    <span className="donut__payment" id={`donut__payment__${currentNum}`} aria-hidden="true">
+                        {periodicPayment}
+                    </span>
+                )}
+                <span className="donut__timestamp" id={`donut__timestamp__${currentNum}`} aria-hidden="true">
+                    {timeStamp}
+                </span>
             </span>
         </div>
     );


### PR DESCRIPTION
## Description

Adds screenreader visual focus on donut text

## Screenshots
![Screenshot 2023-10-30 at 10 13 45 AM](https://github.com/paypal/paypal-messaging-components/assets/123580890/edcf6cee-b1ee-49e6-a90e-ffc1b8fc3052)


## Testing instructions
I suggest using [Browserstack](https://live.browserstack.com/dashboard) to test the following popular combinations of operating systems, screen readers, and browsers: 
- Android OS + Chrome + Screen Reader
- iOS + Safari + VoiceOver
- iOS + Chrome + VoiceOver
- MacOS + Voiceover + safari
- Windows + NVDA + Firefox

1. Navigate to a Pay In 4 Modal
2. Use screen reader to read the payment schedule content
3. Verify that the screen reader says and highlights the content of the payment schedule text correctly.