### PR TITLE
fix: Improve tabbing navigation for Firefox for API modals (DTCRCMERC-2664)

### DIFF
--- a/src/components/modal/v2/parts/Container.jsx
+++ b/src/components/modal/v2/parts/Container.jsx
@@ -104,6 +104,7 @@ const Container = ({ children }) => {
                     {/* Scrollable content */}
                     {/* Iframe variants use the div with className content__wrapper as the contentWrapperRef */}
                     <div
+                        tabindex="-1"
                         className="content__wrapper"
                         ref={!!(!isLander || isIframe) && contentWrapperRef}
                         role={isIframe ? 'dialog' : undefined}


### PR DESCRIPTION
## Description

Discovered while validating tab trap fix for Target (and other API merchants) in production
Target has our lander in an iframe

When tabbing through lander-iframe in firefox, user experienced extra tabs needed with no focus before accessing the product list page tiles.
Remove extra tabbing experience and verify the changes work on all browsers
"content__wrapper" getting keyboard focus

## Testing instructions

test chrome, firefox, and windows
