### PR TITLE
refactor: update method to get release version number for jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,8 @@ pipeline {
             steps {
                 script {
                     if (GIT_COMMIT_MESSAGE.contains('chore(release)')) {
-                        // Assumes commit messages follow this format: chore(release): 1.49.1 [skip ci]
-                        env.VERSION=GIT_COMMIT_MESSAGE.replaceAll(".*\\:|\\[.*", "");
+                        // include only version number section of commit message
+                        env.VERSION=GIT_COMMIT_MESSAGE.substring(GIT_COMMIT_MESSAGE.indexOf(':') + 1, GIT_COMMIT_MESSAGE.indexOf('['))
                         // Stage tags can only contain alphnumeric characters and underscores
                         env.VERSION=VERSION.replace('.', '_').trim();
                         env.stageBundleId='up_stage_v' + VERSION + '_' + GIT_COMMIT_HASH


### PR DESCRIPTION
## Description
Jenkins CI breaking because of CHANGELOG information included in commit. This is an alternative method for getting the release version number to avoid accidentally including extra characters in the stage bundle id.

## Screenshots
N/A

## Testing instructions
use entirety of semantic-release message to mimic release behavior