### PR TITLE
feat: Accessibility - Update tabbing in PPC Modal (DTCRCMERC-2764)

### DIFF
--- a/src/components/modal/v2/lib/utils.js
+++ b/src/components/modal/v2/lib/utils.js
@@ -93,6 +93,10 @@ export function setupTabTrap() {
                 e.preventDefault();
                 tabArray[0].focus();
             }
+            // auto scroll into view for focused element
+            setTimeout(() => {
+                document.activeElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }, 0);
         }
     }
     window.addEventListener('keydown', trapTabKey);


### PR DESCRIPTION
## Description

In PPC Modal, terms and conditions link hidden by Apply now button when tabbed to in **full screen mode**. 

Before:

https://github.com/paypal/paypal-messaging-components/assets/72584889/fd1e93c1-b8f7-4c04-8db5-6057f312f08c



Fix:


https://github.com/paypal/paypal-messaging-components/assets/72584889/ee8df431-1a93-462f-95b4-e59a58971f1b




## Testing instructions
Follow accessibility guidelines for testing
test chrome, firefox, windows etc.