### PR TITLE
refactor: ensure content attribute on meta element is not incorrectly set to undefined after closing modal

### DIFF
--- a/src/library/zoid/modal/prerenderTemplate.jsx
+++ b/src/library/zoid/modal/prerenderTemplate.jsx
@@ -154,7 +154,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
             height: 24px;
         }
 
-        @media (max-width: 639px) {
+        @media screen and (max-width: 639px) {
             .close-button > button > svg {
                 margin-top: auto;
                 margin-left: auto;
@@ -172,7 +172,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
         `
         }
 
-        @media (max-width: 639px), (max-height: 539px){
+        @media screen and (max-width: 639px), (max-height: 539px){
             .modal{
                 overflow-y: hidden;
             }

--- a/src/library/zoid/modal/prerenderTemplate.jsx
+++ b/src/library/zoid/modal/prerenderTemplate.jsx
@@ -24,7 +24,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
         }
         ${
             useNewCheckoutDesign === 'true'
-                ? ` @media (min-device-width: 640px) {
+                ? ` @media screen and (min-width: 640px) {
                     .overlay {
                         background-color: #f1f2f3;        
                         position: fixed;
@@ -37,7 +37,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
                         border: 1px solid #cdd0d4;
                     }
                 }
-                @media (max-device-width: 639px) {
+                @media screen and (max-width: 639px) {
                     .overlay {
                         background-color: #f1f2f3;
                         position: fixed;
@@ -66,7 +66,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
         ${
             useNewCheckoutDesign === 'true' &&
             `
-                @media screen and (min-device-width: 640px) {
+                @media screen and (min-width: 640px) {
                     #prerender-close-btn {
                         position: relative;
                     }
@@ -80,7 +80,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
                         z-index: 50;
                     }
                 }
-                @media screen and (max-device-width: 639px) {
+                @media screen and (max-width: 639px) {
                     #prerender-close-btn {
                         left: 0;
                     }
@@ -154,7 +154,7 @@ export default ({ doc, props: { cspNonce, features, onError }, event, state }) =
             height: 24px;
         }
 
-        @media (max-device-width: 639px) {
+        @media (max-width: 639px) {
             .close-button > button > svg {
                 margin-top: auto;
                 margin-left: auto;

--- a/src/utils/miscellaneous.js
+++ b/src/utils/miscellaneous.js
@@ -177,7 +177,9 @@ export const viewportHijack = memoize(() => {
             document.body.style.setProperty('-ms-overflow-style', 'scrollbar');
         },
         () => {
-            viewport.setAttribute('content', viewport.__pp_prev_content__);
+            if (viewport.__pp_prev_content__) {
+                viewport.setAttribute('content', viewport.__pp_prev_content__);
+            }
             delete viewport.__pp_prev_content__;
 
             document.body.style.setProperty('overflow', document.body.__pp_prev_overflow__);


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

- Small style tweaks to prerender template to ensure media queries work as expected.
- Ensures that meta element's content attribute is not incorrectly set to `undefined` resulting in mobile views switching to desktop sizing.

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
