### PR TITLE
fix: moves hidden modal offscreen so right click is not interrupted on safari

### DIFF
--- a/src/library/zoid/modal/containerTemplate.jsx
+++ b/src/library/zoid/modal/containerTemplate.jsx
@@ -112,6 +112,11 @@ export default ({ uid, frame, prerenderFrame, doc, event, state, props: { cspNon
                         border: none !important;
                     }
 
+                    #${uid}.${CLASS.HIDDEN} > div > iframe {
+                        top: -99999px !important;
+                        left: -99999px !important;
+                    }
+
                     #${uid} > div {
                         background: rgba(108, 115, 120, 0);
                         transition: background ${TRANSITION_DELAY}ms linear;


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

An issue was reported in Safari where the modal iframe was taking over the entire page and intercepting pointer events even after the user dismissed the modal, which prevents a user from right clicking to interact with merchant page content.

Cause for this affecting only Safari could not be determined.  Resolution is to move modal offscreen even when hidden.
<!-- Describe your changes and what problem they solve -->

## Testing instructions

1. In safari, open modal, then close it. 
2. Right-click anywhere on the page.  "Open Frame in New Tab" should not be present, or if it is, should not open a paypal link.  "Inspect Element" should not reveal elements in the modal.  

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
