### PR TITLE
fix: relax PPC inline replace

### DIFF
--- a/src/server/locale/US/PAYPAL_CREDIT/mutations/ppc_ni_nq.js
+++ b/src/server/locale/US/PAYPAL_CREDIT/mutations/ppc_ni_nq.js
@@ -111,7 +111,7 @@ export default {
                     },
                     {
                         tag: 'medium',
-                        replace: [['$99+.', '$99+']],
+                        replace: [['9+.', '9+']],
                         br: ['purchases']
                     }
                 ]
@@ -130,7 +130,7 @@ export default {
                     },
                     {
                         tag: 'medium',
-                        replace: [['$99+.', '$99+']],
+                        replace: [['9+.', '9+']],
                         br: ['purchases']
                     }
                 ]


### PR DESCRIPTION
## Description

- PayPal Credit No Interest minimum amount updated that conflicted with the existing matching rule to remove the trailing period from the content. The rule has been made less strict to be more flexible to match more values.

## Screenshots

N/A

## Testing instructions

N/A
