### PR TITLE
fix: (LIVE ISSUE) DE GPL LT: Calculator in app does not properly display APRs

### DIFF
--- a/src/components/modal/v2/parts/views/LongTerm/styles.scss
+++ b/src/components/modal/v2/parts/views/LongTerm/styles.scss
@@ -21,7 +21,6 @@
 }
 
 .nav__link-prefix {
-    min-width: 315px;
     padding: 0px;
     font-size: 14px;
     margin: 0px;

--- a/src/components/modal/v2/styles/components/_body-content.scss
+++ b/src/components/modal/v2/styles/components/_body-content.scss
@@ -76,6 +76,9 @@
     @include desktop {
         max-height: 90vh;
     }
+    @include mobile {
+        min-width: 285px;
+    }
 
     @include lander {
         height: auto;

--- a/src/components/modal/v2/styles/components/_offer-accordion.scss
+++ b/src/components/modal/v2/styles/components/_offer-accordion.scss
@@ -1,3 +1,5 @@
+@import '../globals/mixins';
+
 .accordion {
     &__container {
         border: 1px solid $light-gray;
@@ -81,6 +83,9 @@
             display: flex;
             justify-content: space-between;
             padding: 25px 18px 0px 13px;
+            @include smallMobile {
+                padding-top: 22px;
+            }
             &:first-child {
                 padding-top: 0px;
 

--- a/src/components/modal/v2/styles/components/_offer-accordion.scss
+++ b/src/components/modal/v2/styles/components/_offer-accordion.scss
@@ -83,9 +83,11 @@
             display: flex;
             justify-content: space-between;
             padding: 25px 18px 0px 13px;
+
             @include smallMobile {
                 padding-top: 22px;
             }
+
             &:first-child {
                 padding-top: 0px;
 

--- a/src/components/modal/v2/styles/components/_offer-accordion.scss
+++ b/src/components/modal/v2/styles/components/_offer-accordion.scss
@@ -77,16 +77,16 @@
         .open & {
             height: 172px;
             transition: height 0.2s linear;
+
+            @include smallMobile {
+                height: 190px;
+            }
         }
 
         .accordion__row {
             display: flex;
             justify-content: space-between;
             padding: 25px 18px 0px 13px;
-
-            @include smallMobile {
-                padding-top: 22px;
-            }
 
             &:first-child {
                 padding-top: 0px;


### PR DESCRIPTION


## Description

Live Issue reported: https://paypal.atlassian.net/browse/DTCRCMERC-3699
DE GPL LT small mobile view in firefox, aprs are cut off in the accordion dropdown. 

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
