### PR TITLE
refactor: fix de lt calculator spacing

### DIFF
--- a/src/components/modal/v2/styles/components/_offer-accordion.scss
+++ b/src/components/modal/v2/styles/components/_offer-accordion.scss
@@ -75,11 +75,12 @@
         transition: height 0.2s linear;
 
         .open & {
-            height: 172px;
+            min-height: 172px;
             transition: height 0.2s linear;
-
+            margin-bottom: inherit;
+            
             @include smallMobile {
-                height: 190px;
+                min-height: 190px;
             }
         }
 


### PR DESCRIPTION
## Description
add spacing to prevent text cut off when modal displays within PayPal app

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions
N/A
