### PR TITLE
fix: corrects page type tracking value cache poisoning

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -30,7 +30,8 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
         merchantConfigHash: window.xprops.merchantConfigHash ?? null,
         disableSetCookie: window.xprops.disableSetCookie ?? null,
         features: window.xprops.features ?? null,
-        contextualComponents: window.xprops.contextualComponents ?? null
+        contextualComponents: window.xprops.contextualComponents ?? null,
+        pageType: window.xprops.pageType ?? null
     });
 
     const [serverData, setServerData] = createState({
@@ -129,7 +130,8 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     contextualComponents,
                     treatmentsHash,
                     disableSetCookie,
-                    features
+                    features,
+                    pageType
                 } = xprops;
 
                 setProps({
@@ -146,7 +148,8 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     channel,
                     contextualComponents,
                     disableSetCookie,
-                    features
+                    features,
+                    pageType
                 });
 
                 // Generate new MRID on message update.
@@ -172,7 +175,8 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     deviceID: getOrCreateDeviceID(),
                     treatments: treatmentsHash,
                     disableSetCookie,
-                    features
+                    features,
+                    pageType
                 })
                     .filter(([, val]) => Boolean(val))
                     .reduce(

--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -211,9 +211,12 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                 value: ({ props }) => {
                     const { onReady } = props;
                     return ({ meta, activeTags, ts, requestDuration, messageRequestId }) => {
-                        const { account, merchantId, index, modal, getContainer } = props;
+                        const { account, merchantId, index, modal, getContainer, pageType } = props;
                         const { trackingDetails, offerType, ppDebugId } = meta;
                         const partnerClientId = merchantId && account.slice(10); // slice is to remove the characters 'client-id:' from account name
+
+                        // overwrites potentially poisoned PAGE_TYPE value from cached trackingDetails
+                        trackingDetails.PAGE_TYPE = pageType;
 
                         ppDebug(`Message Correlation ID: ${ppDebugId}`);
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -8,7 +8,7 @@ import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { getGlobalUrl } from './global';
 import { request } from './miscellaneous';
 
-import { getLibraryVersion, getDisableSetCookie } from './sdk';
+import { getLibraryVersion, getDisableSetCookie, getPageType } from './sdk';
 
 function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
     const { deviceID, sessionID, integration_type, messaging_version } = meta.global ?? {};
@@ -56,6 +56,7 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
             // eslint-disable-next-line compat/compat
             const clickUrlParams = new URLSearchParams(clickUrl);
             const fdata = clickUrlParams.get('fdata');
+            const pageType = getPageType();
 
             return {
                 component_type: type,
@@ -65,6 +66,9 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
                 merchant_events: bizEvents.filter(event => event.payload?.index === index),
                 ...trackingDetails,
                 ...stats,
+
+                // overwrites potentially poisoned PAGE_TYPE value from cached trackingDetails
+                PAGE_TYPE: pageType,
 
                 component_events: componentEvents
                     .filter(({ event_type }) => event_type !== 'MORS')

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -8,7 +8,7 @@ import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { getGlobalUrl } from './global';
 import { request } from './miscellaneous';
 
-import { getLibraryVersion, getDisableSetCookie, getPageType } from './sdk';
+import { getLibraryVersion, getDisableSetCookie } from './sdk';
 
 function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
     const { deviceID, sessionID, integration_type, messaging_version } = meta.global ?? {};
@@ -56,7 +56,6 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
             // eslint-disable-next-line compat/compat
             const clickUrlParams = new URLSearchParams(clickUrl);
             const fdata = clickUrlParams.get('fdata');
-            const pageType = getPageType();
 
             return {
                 component_type: type,
@@ -66,9 +65,6 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
                 merchant_events: bizEvents.filter(event => event.payload?.index === index),
                 ...trackingDetails,
                 ...stats,
-
-                // overwrites potentially poisoned PAGE_TYPE value from cached trackingDetails
-                PAGE_TYPE: pageType,
 
                 component_events: componentEvents
                     .filter(({ event_type }) => event_type !== 'MORS')


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description
Message page type tracking values have been frequently misreported due to CDN-cached and thus potentially poisoned tracking values being tracked instead of the value a merchant specifies.  This bug fix provides the merchant-provided page type value for tracking.

It also passes the page type in the message req query params on message re-render.
<!-- Describe your changes and what problem they solve -->

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

Request a paypal message with a specified page type.  Use a tool like Proxyman to intercept the response and replace the PAGE_TYPE value from the meta tracking keys.  Validate that the original, not the intercepted and replaced, tracking key value was logged in the glog req payload. 
<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
