### PR TITLE
fix: page type format in req query

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -176,7 +176,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     treatments: treatmentsHash,
                     disableSetCookie,
                     features,
-                    pageType
+                    page_type: pageType
                 })
                     .filter(([, val]) => Boolean(val))
                     .reduce(


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description
Fixes page type format in request query from `pageType` to `page_type` to match consuming app's valid schema.
<!-- Describe your changes and what problem they solve -->

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
