### PR TITLE
fix: prefix client-id for lander modal events

### DIFF
--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -6,6 +6,19 @@ import { isIframe } from './utils';
 const IOS_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
 const ANDROID_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
 
+const getAccount = (merchantId, clientId, payerId) => {
+    if (merchantId) {
+        return merchantId;
+    }
+
+    // Logger endpoint expects account field to be prefixed if the value is a clientId
+    if (clientId) {
+        return `client-id:${clientId}`;
+    }
+
+    return payerId;
+};
+
 const setupBrowser = props => {
     window.xprops = {
         // We will never recieve new props via this integration style
@@ -39,7 +52,7 @@ const setupBrowser = props => {
                         // TODO: This should likely be specific to this integration type
                         type: 'modal',
                         // messageRequestId,
-                        account: merchantId || clientId || payerId,
+                        account: getAccount(merchantId, clientId, payerId),
                         trackingDetails
                     }
                 };


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

The lander modal was sending logging events with `clientId` un-prefixed.

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
