### PR TITLE
fix: fix period placement

### DIFF
--- a/content/messages/US/long_term_multi_gtz_3mez.json
+++ b/content/messages/US/long_term_multi_gtz_3mez.json
@@ -21,7 +21,7 @@
         ["Buy now and pay later.", ["xsmall.2"]],
         [
             [
-                "As low as ${formattedMonthlyPayment}/<span aria-hidden='true'>mo</span><span class='sr-only'>month</span> or 0% APR."
+                "As low as ${formattedMonthlyPayment}/<span aria-hidden='true'>mo</span><span class='sr-only'>month</span> or 0% APR for 3 months."
             ],
             ["small", "medium", "large", "xlarge"]
         ]

--- a/src/server/locale/US/PAY_LATER_LONG_TERM/mutations/long_term_multi_gtz_3mez.js
+++ b/src/server/locale/US/PAY_LATER_LONG_TERM/mutations/long_term_multi_gtz_3mez.js
@@ -125,7 +125,7 @@ export default {
                         tag: 'medium',
                         br: ['mo.', 'mo'],
                         replace: [
-                            ['APR.', 'APR'],
+                            ['months.', 'months'],
                             ['mo.', 'mo']
                         ]
                     },
@@ -146,7 +146,7 @@ export default {
                         tag: 'medium',
                         br: ['mo.', 'mo'],
                         replace: [
-                            ['APR.', 'APR'],
+                            ['months.', 'months'],
                             ['mo.', 'mo']
                         ]
                     },


### PR DESCRIPTION
## Description
fix placement of period for inline and none logo types on new message

## Screenshots
<img width="493" alt="Screenshot 2025-06-06 at 10 50 53 AM" src="https://github.com/user-attachments/assets/0f301893-e800-437a-b20d-d82b70dfe7c3" />

## Testing instructions
N/A