### PR TITLE
feat: Update our Automated Accessibility testing to be compliant for levels to (WCAG) 2.2 Levels A and AA

### DIFF
--- a/tests/playwright/pages/base.js
+++ b/tests/playwright/pages/base.js
@@ -15,7 +15,7 @@ export const generateUrl = (baseUrl, { account, amount, offer }) => {
 };
 // Common function for running Axe accessibility scans
 const runAxeCoreScan = async (page, options = {}) => {
-    const tags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'];
+    const tags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa', 'best-practice'];
     const { disableRules = [] } = options; // Optionally pass disable rules
 
     const results = await new AxeBuilder({ page })


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

A recent update to our compliance levels require us to update our automated accessibility testing to meet standard levels to (WCAG) 2.2 Levels A and AA. Currently we are compliant for levels 2.0.A, 2.1A, 2.0AA, 2.1AA, best-practice in messaging components.

Added **wcag22aa** tag to tests
time for tests - remained the same

## Screenshots
<img width="719" height="250" alt="Screenshot 2025-07-24 at 1 59 44 PM" src="https://github.com/user-attachments/assets/d6b07d77-5887-4e3b-b06b-e4e651da3e08" />

https://github.com/user-attachments/assets/4333c709-c63d-47cc-936d-8c209e1a9262



<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

run `npx playwright test --ui `

