### PR TITLE
feat: Implements Global Session ID

### DIFF
--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -14,6 +14,7 @@ import {
     getLibraryVersion,
     runStats,
     logger,
+    getOrCreateGlobalSessionID,
     getSessionID,
     getGlobalState,
     getCurrentTime,
@@ -248,6 +249,8 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                     // deviceID from internal iframe storage
                                     // should be populated previously by the treatments component
                                     deviceID: getOrCreateDeviceID(),
+                                    // Global Session ID allows messages to be correlated to button events
+                                    globalSessionID: getOrCreateGlobalSessionID(),
                                     // Session ID from parent local storage,
                                     sessionID: getSessionID()
                                 },

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -11,7 +11,7 @@ import { request } from './miscellaneous';
 import { getLibraryVersion, getDisableSetCookie } from './sdk';
 
 function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
-    const { deviceID, sessionID, integration_type, messaging_version } = meta.global ?? {};
+    const { deviceID, sessionID, integration_type, messaging_version, globalSessionID } = meta.global ?? {};
 
     let clientID;
     if (account.startsWith('client-id:')) {
@@ -98,6 +98,7 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
 
             // Global Details
             device_id: deviceID,
+            global_session_id: globalSessionID,
             session_id: sessionID,
             integration_type,
             integration_version: messaging_version,

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -168,16 +168,13 @@ export function getStorage() {
 // and used to correlate with button events
 export function getOrCreateGlobalSessionID() {
     if (__MESSAGES__.__TARGET__ === 'SDK') {
-        const globalSessionID = getSDKGlobalSessionID();
-
-        if (globalSessionID) {
-            return globalSessionID;
-        } else {
-            const globalSessionIDValue = createBelterID();
-            setSDKGlobalSessionID(globalSessionIDValue);
-
-            return globalSessionIDValue;
+        let globalSessionID = getSDKGlobalSessionID();
+        if (!globalSessionID) {
+            globalSessionID = createBelterID();
+            setSDKGlobalSessionID(globalSessionID);
         }
+
+        return globalSessionID;
     } else {
         return undefined;
     }

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,6 +1,6 @@
 /* eslint-disable eslint-comments/disable-enable-pair, no-else-return */
 import arrayFrom from 'core-js-pure/stable/array/from';
-import { getStorage as getBelterStorage } from '@krakenjs/belter/src';
+import { getStorage as getBelterStorage, uniqueID as createBelterID } from '@krakenjs/belter/src';
 import { SDK_QUERY_KEYS, SDK_SETTINGS } from '@paypal/sdk-constants/src';
 import {
     getClientID,
@@ -14,6 +14,8 @@ import {
     getCSPNonce,
     getNamespace as getSDKNamespace,
     getDefaultNamespace as getDefaultSDKNamespace,
+    getGlobalSessionID as getSDKGlobalSessionID,
+    setGlobalSessionID as setSDKGlobalSessionID,
     getSessionID as getSDKSessionID,
     getStorageID as getSDKStorageID,
     getStorageState as getSDKStorageState,
@@ -159,6 +161,26 @@ export function isZoidComponent() {
 
 export function getStorage() {
     return getBelterStorage({ name: getNamespace() });
+}
+
+// Uses SDK methods to get and set a global session ID
+// value will be passed in message_render events
+// and used to correlate with button events
+export function getOrCreateGlobalSessionID() {
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        const globalSessionID = getSDKGlobalSessionID();
+
+        if (globalSessionID) {
+            return globalSessionID;
+        } else {
+            const globalSessionIDValue = createBelterID();
+            setSDKGlobalSessionID(globalSessionIDValue);
+
+            return globalSessionIDValue;
+        }
+    } else {
+        return undefined;
+    }
 }
 
 // Use SDK methods when available, otherwise manually fetch storage via belter

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -176,7 +176,7 @@ export function getOrCreateGlobalSessionID() {
 
         return globalSessionID;
     } else {
-        return undefined;
+        return getStorage().getSessionID();
     }
 }
 


### PR DESCRIPTION
## Description
- Adds a global_session_id for correlating events across different use cases
- getOrCreateSessionID uses belter for generating uid
- Not applicable in standalone use case

## Screenshots
Passes global_session_id to logger for tracking
<img width="754" height="355" alt="image" src="https://github.com/user-attachments/assets/715fc5f2-5d17-4432-a782-ca79ab1ca286" />


## Testing instructions
Validated sdk via cdn stage bundle as well as downstream internal applications to accept the event for tracking purposes
