### PR TITLE
feat:Updated message logo container for the decorative images (DTCRCMERC-4563)

### DIFF
--- a/src/server/message/parts/Logo.jsx
+++ b/src/server/message/parts/Logo.jsx
@@ -10,7 +10,7 @@ const Logos = ({ mutations }) => {
         <div className="message__logo-container" aria-hidden="true">
             {logos.map(({ src, dimensions: [width, height] }) => (
                 <div className="message__logo message__logo--svg">
-                    <img src={src} alt="" />
+                    <img src={src} alt="" role="presentation" />
                     <canvas height={height} width={width} />
                 </div>
             ))}

--- a/src/server/message/parts/Logo.jsx
+++ b/src/server/message/parts/Logo.jsx
@@ -10,7 +10,7 @@ const Logos = ({ mutations }) => {
         <div className="message__logo-container" aria-hidden="true">
             {logos.map(({ src, dimensions: [width, height] }) => (
                 <div className="message__logo message__logo--svg">
-                    <img src={src} alt="PayPal" />
+                    <img src={src} alt="" />
                     <canvas height={height} width={width} />
                 </div>
             ))}

--- a/tests/unit/spec/server/message/index.test.js
+++ b/tests/unit/spec/server/message/index.test.js
@@ -121,7 +121,7 @@ describe('SSR message', () => {
             expect(getByText(subHeadline)).toBeInTheDocument();
             expect(getByText(disclaimer)).toBeInTheDocument();
 
-            expect(getByAltText('PayPal')).toHaveAttribute('src', logoSrc);
+            expect(getByAltText('')).toHaveAttribute('src', logoSrc);
         });
         const getMatchPattern = (cssSelector, cssValue) => {
             // convert plain string css into an array if RegExps


### PR DESCRIPTION


<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

Currently our message logo container have conflicting a11y labels and need to be updated accordingly.

Removed the alt tags from the logos and make them decorative according to a11y standards. 

repo: paypal-messaging-components

## Screenshots
Tested on: https://localhost.paypal.com:8080/standalone.html

<img width="796" height="163" alt="Screenshot 2025-12-11 at 9 52 04 PM" src="https://github.com/user-attachments/assets/fdc8f765-6d7a-4439-80de-5ded12705eec" />


## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
