### PR TITLE
fix: country-specific margins for preapproval label in checkout header

### DIFF
--- a/src/components/modal/v2/parts/CheckoutHeader.jsx
+++ b/src/components/modal/v2/parts/CheckoutHeader.jsx
@@ -79,7 +79,11 @@ const CheckoutHeader = ({
                         // eslint-disable-next-line react/no-danger
                         dangerouslySetInnerHTML={{ __html: isPreapproved === 'true' ? preapprovalHeadline : headline }}
                     />
-                    {isPreapproved === 'true' ? <span className="preapproved-label">{preapprovalLabel}</span> : ''}
+                    {isPreapproved === 'true' ? (
+                        <span className={`preapproved-label ${countryClassName}`}>{preapprovalLabel}</span>
+                    ) : (
+                        ''
+                    )}
                 </div>
                 {isQualifying === 'true' && qualifyingSubheadline !== '' ? (
                     <p className={`subheadline_p subheadline-${countryClassName} qualifying checkout`}>

--- a/src/components/modal/v2/styles/components/_header.scss
+++ b/src/components/modal/v2/styles/components/_header.scss
@@ -430,10 +430,10 @@
                 }
 
                 &.gb {
-                    margin: 3px 0px -50px -130px;
+                    margin: 3px 0px -50px -140px;
 
                     @include mixins.mobile {
-                        margin: 3px 0px -50px -130px;
+                        margin: 3px 0px -50px -140px;
                     }
                     @include mixins.smallMobile {
                         margin: 3px 0px -50px -60px;
@@ -443,7 +443,7 @@
                         margin: 30px 0px -50px -70px;
 
                         @include mixins.mobile {
-                            margin: 5px 0px -50px -130px;
+                            margin: 5px 0px -50px -140px;
                         }
 
                         @include mixins.smallMobile {

--- a/src/components/modal/v2/styles/components/_header.scss
+++ b/src/components/modal/v2/styles/components/_header.scss
@@ -420,24 +420,35 @@
                 color: #0066f5;
                 border-radius: 6px;
                 padding: 2px 8px;
-                margin: 3px 0px -50px -130px;
 
-                @include mixins.mobile {
-                    margin: 3px 0px -50px -130px;
-                }
-                @include mixins.smallMobile {
-                    margin: 3px 0px -50px -60px;
-                }
-
-                @include mixins.lander {
-                    margin: 30px 0px -50px -70px;
+                &.us {
+                    margin: 0px 0px -20px 10px;
 
                     @include mixins.mobile {
-                        margin: 5px 0px -50px -130px;
+                        margin: 10px 0px -10px 10px;
+                    }
+                }
+
+                &.gb {
+                    margin: 3px 0px -50px -130px;
+
+                    @include mixins.mobile {
+                        margin: 3px 0px -50px -130px;
+                    }
+                    @include mixins.smallMobile {
+                        margin: 3px 0px -50px -60px;
                     }
 
-                    @include mixins.smallMobile {
-                        margin: 5px 0px -50px -60px;
+                    @include mixins.lander {
+                        margin: 30px 0px -50px -70px;
+
+                        @include mixins.mobile {
+                            margin: 5px 0px -50px -130px;
+                        }
+
+                        @include mixins.smallMobile {
+                            margin: 5px 0px -50px -60px;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

Adds country class name to preapproval label and restructures SCSS to support US and GB specific margins, ensuring proper positioning across different regions and breakpoints.


<!-- Describe your changes and what problem they solve -->

## Screenshots

### Before the fix (Pi4 US)

<img width="1406" height="900" alt="Screenshot 2026-01-28 at 7 48 51 AM" src="https://github.com/user-attachments/assets/0d36dd35-5da1-4f60-83de-99c53e838792" />

### After the fix (Pi4 US/Pi3 UK)

- **Pi4 US**

<img width="1181" height="881" alt="Screenshot 2026-01-28 at 11 57 22 AM" src="https://github.com/user-attachments/assets/2d41adf6-dbcc-4d9e-bef8-4228de296490" />

- **Pi3 UK**

<img width="1178" height="900" alt="Screenshot 2026-01-28 at 11 59 24 AM" src="https://github.com/user-attachments/assets/d9f2076c-4282-47d4-b89f-ec4e3aa5ab20" />


<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
