### PR TITLE
[R2] [SDK] Investigate alternative modal postMessenger origin (DTCRCMERC-4102)

### DIFF
--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -1,7 +1,7 @@
 /* global Android */
 import { isAndroidWebview, isIosWebview, getPerformance } from '@krakenjs/belter/src';
 import { getOrCreateDeviceID, logger } from '../../../../utils';
-import { validateProps, isIframe } from './utils';
+import { validateProps } from './utils';
 import { sendEvent, createPostMessengerEvent, POSTMESSENGER_EVENT_NAMES } from './postMessage';
 
 const IOS_INTERFACE_NAME = 'paypalMessageModalCallbackHandler';
@@ -66,15 +66,28 @@ const getAccount = (merchantId, clientId, payerId) => {
 
 const setupBrowser = props => {
     const propListeners = new Set();
+    const handshakeEventNames = new Set(['PROPS_UPDATE', 'MODAL_CLOSED']);
+    let trustedOrigin = '';
 
-    let trustedOrigin = decodeURIComponent(props.origin || '');
-    if (isIframe && document.referrer && !process.env.NODE_ENV === 'test') {
-        trustedOrigin = new window.URL(document.referrer).origin;
+    if (document.referrer) {
+        try {
+            trustedOrigin = new window.URL(document.referrer).origin;
+        } catch (error) {
+            trustedOrigin = '';
+        }
     }
 
     window.addEventListener(
         'message',
         event => {
+            if (
+                !trustedOrigin &&
+                event?.origin &&
+                event?.data?.eventName &&
+                handshakeEventNames.has(event.data.eventName)
+            ) {
+                trustedOrigin = event.origin;
+            }
             handleBrowserEvents(trustedOrigin, propListeners, event);
         },
         false
@@ -286,8 +299,10 @@ export default function polyfillZoid() {
         }, {});
 
     const { userAgent } = window.navigator;
+    const isWebview = isIosWebview(userAgent) || isAndroidWebview(userAgent);
+    const isEmbedded = window.parent !== window || Boolean(window.opener);
 
-    if (isIosWebview(userAgent) || isAndroidWebview(userAgent)) {
+    if (isWebview && !isEmbedded) {
         setupWebview(props);
     } else {
         setupBrowser(props);

--- a/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
+++ b/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
@@ -87,6 +87,18 @@ const mockLoadUrl = (url, { platform = 'web' } = {}) => {
         })()
     };
 };
+const setDocumentReferrer = value => {
+    Object.defineProperty(window.document, 'referrer', {
+        configurable: true,
+        get: () => value
+    });
+};
+const setWindowParent = value => {
+    Object.defineProperty(window, 'parent', {
+        configurable: true,
+        value
+    });
+};
 
 describe('zoidPollyfill', () => {
     beforeAll(() => {
@@ -408,31 +420,61 @@ describe('zoidPollyfill', () => {
             expect(postMessage).toHaveBeenCalledTimes(1);
             expect(postMessage.mock.calls[0][0]).toEqual(expect.any(String));
             expect(JSON.parse(postMessage.mock.calls[0][0])).toMatchInlineSnapshot(`
+            Object {
+              "args": Array [
                 Object {
-                  "args": Array [
-                    Object {
-                      "__shared__": Object {
-                        "credit_product_identifiers": Array [
-                          "PAY_LATER_LONG_TERM_US",
-                        ],
-                        "fdata": "123abc",
-                        "offer_country_code": "US",
-                      },
-                      "event_type": "modal_rendered",
-                      "render_duration": "50",
-                      "request_duration": "100",
-                    },
-                  ],
-                  "name": "onReady",
-                }
-            `);
+                  "__shared__": Object {
+                    "credit_product_identifiers": Array [
+                      "PAY_LATER_LONG_TERM_US",
+                    ],
+                    "fdata": "123abc",
+                    "offer_country_code": "US",
+                  },
+                  "event_type": "modal_rendered",
+                  "render_duration": "50",
+                  "request_duration": "100",
+                },
+              ],
+              "name": "onReady",
+            }
+        `);
             postMessage.mockClear();
+        });
+        test('uses browser flow for webview when embedded in iframe', () => {
+            addEventListenerSpy.mockClear();
+            const parentWindow = { postMessage: jest.fn() };
+            setWindowParent(parentWindow);
+            mockLoadUrl(
+                'https://localhost.paypal.com:8080/credit-presentment/native/modal?client_id=client_1&logo_type=inline&amount=500&dev_touchpoint=true',
+                {
+                    platform: 'ios'
+                }
+            );
+            setDocumentReferrer('http://example.com/lander');
+
+            zoidPolyfill();
+
+            expect(window.actions).toBeUndefined();
+            expect(window.xprops).toEqual(
+                expect.objectContaining({
+                    onProps: expect.any(Function),
+                    onReady: expect.any(Function),
+                    onClick: expect.any(Function),
+                    onCalculate: expect.any(Function),
+                    onShow: expect.any(Function),
+                    onClose: expect.any(Function)
+                })
+            );
+
+            setWindowParent(window);
+            addEventListenerSpy.mockClear();
         });
         describe('browser', () => {
             beforeAll(() => {
                 mockLoadUrl(
-                    'https://localhost.paypal.com:8080/credit-presentment/lander/modal?client_id=client_1&logo_type=inline&amount=500&devTouchpoint=true&origin=http://example.com'
+                    'https://localhost.paypal.com:8080/credit-presentment/lander/modal?client_id=client_1&logo_type=inline&amount=500&devTouchpoint=true'
                 );
+                setDocumentReferrer('http://example.com/lander');
                 zoidPolyfill();
             });
             afterEach(() => {
@@ -523,13 +565,40 @@ describe('zoidPollyfill', () => {
                 expect(onPropsCallback).toHaveBeenCalledTimes(0);
             });
         });
+        describe('browser without referrer', () => {
+            beforeAll(() => {
+                mockLoadUrl(
+                    'https://localhost.paypal.com:8080/credit-presentment/lander/modal?client_id=client_1&logo_type=inline&amount=500&devTouchpoint=true'
+                );
+                setDocumentReferrer('');
+                zoidPolyfill();
+            });
+            afterEach(() => {
+                addEventListenerSpy.mockClear();
+            });
+            test('sets trusted origin from first valid postMessage', () => {
+                const postMessageEvent = new MessageEvent('message', {
+                    origin: 'http://example.com',
+                    data: {
+                        eventName: 'PROPS_UPDATE',
+                        id: 'event-1',
+                        eventPayload: { amount: 1000 }
+                    }
+                });
+
+                window.dispatchEvent(postMessageEvent);
+
+                expect(window.parent.postMessage).toHaveBeenCalledWith(expect.any(Object), 'http://example.com');
+            });
+        });
     });
 
     describe('communication with parent window on modal events ', () => {
         beforeAll(() => {
             mockLoadUrl(
-                'https://localhost.paypal.com:8080/credit-presentment/lander/modal?client_id=client_1&logo_type=inline&amount=500&devTouchpoint=true&origin=http://localhost.paypal.com:8080'
+                'https://localhost.paypal.com:8080/credit-presentment/lander/modal?client_id=client_1&logo_type=inline&amount=500&devTouchpoint=true'
             );
+            setDocumentReferrer('http://localhost.paypal.com:8080/lander');
             zoidPolyfill();
         });
         afterEach(() => {


### PR DESCRIPTION
  ## Description

This change removes reliance on the origin query parameter and makes trusted‑origin detection more robust across browsers and WebViews. In setupBrowser, we now initialize trustedOrigin from document.referrer when it is available, and otherwise establish it from the first valid postMessage event (event.origin). That keeps message validation tied to the browser’s security model instead of URL params. We also updated the WebView routing so that embedded WebViews (iframes/popups) use the browser postMessage flow, while top‑level WebViews continue to use the native bridge via setupWebview. The unit tests were updated to remove origin params in URLs, add a no‑referrer handshake test, and validate the WebView‑iframe behavior.

[JIRA Ticket](https://paypal.atlassian.net/browse/DTCRCMERC-4102?atlOrigin=eyJpIjoiYmE0YWRlMzI0NzNhNGE2MzkyMmM2MmZiZTM2YTMxY2UiLCJwIjoiaiJ9)

## The New Flow

<img width="1683" height="1254" alt="image" src="https://github.com/user-attachments/assets/3f4c09ac-0fe4-45e5-8108-323eed376639" />


  ## Screenshots

  #### Testing Modal Presentation Mode | https://www.te-v6-wsnw.qa.paypal.com/web-sdk/demo/edit/pattern/paypalMessages

<img width="1510" height="861" alt="image" src="https://github.com/user-attachments/assets/969fe49f-708f-47d6-8b3d-29102fa77d16" />


  #### Testing Popup Presentation Mode | https://www.te-v6-wsnw.qa.paypal.com/web-sdk/demo/edit/pattern/paypalMessages

<img width="1504" height="855" alt="image" src="https://github.com/user-attachments/assets/065b2961-0d7d-496b-b94e-03eda81d4ecc" />


  #### Testing Redirect Presentation Mode | https://www.te-v6-wsnw.qa.paypal.com/web-sdk/demo/edit/pattern/paypalMessages

<img width="1512" height="733" alt="image" src="https://github.com/user-attachments/assets/fdfc3373-775c-4d26-ab50-f0afafa6ba57" />


  #### Testing WebView Modal iOS | https://www.te-v6-wsnw.qa.paypal.com/web-sdk/demo/edit/pattern/paypalMessages

<img width="1384" height="893" alt="Screenshot 2026-01-30 at 12 56 33 AM" src="https://github.com/user-attachments/assets/267814a9-3689-462f-883b-0ba1568dcdce" />
  
  #### Testing WebView Modal Android | https://www.te-v6-wsnw.qa.paypal.com/web-sdk/demo/edit/pattern/paypalMessages
  
<img width="1504" height="901" alt="Screenshot 2026-01-30 at 12 45 04 AM" src="https://github.com/user-attachments/assets/d3ea9544-0c4d-46f7-85c1-3cdc33bfb595" />

  ## Testing instructions

  - npm test -- tests/unit/spec/src/components/modal/v2/lib/
    zoid-polyfill.test.js
 - I mimicked the postMessage flow by adding the following to the dom `<meta name="referrer" content="no-referrer">`