### PR TITLE
feat: add experiment gating for US and GB preapproval badge

### DIFF
--- a/content/modals/GB/short_term_xo.json
+++ b/content/modals/GB/short_term_xo.json
@@ -9,6 +9,7 @@
         "useV5Design": "true",
         "apr": "{apr}",
         "preapproved": "false",
+        "showPreapprovedBadge": "false",
         "variables": {
             "transaction_amount": "${eval(transaction_amount ? transaction_amount : '-')}",
             "qualifying_offer": "${eval(CREDIT_OFFERS_DS.qualifying_offer ? CREDIT_OFFERS_DS.qualifying_offer : 'false')}",

--- a/content/modals/US/v2_short_term_xo.json
+++ b/content/modals/US/v2_short_term_xo.json
@@ -9,6 +9,7 @@
         "apr": "{apr}",
         "useV5Design": "true",
         "preapproved": "false",
+        "showPreapprovedBadge": "false",
         "variables": {
             "transaction_amount": "${eval(transaction_amount ? transaction_amount : '-')}",
             "qualifying_offer": "${eval(CREDIT_OFFERS_DS.qualifying_offer ? CREDIT_OFFERS_DS.qualifying_offer : 'false')}",

--- a/src/components/modal/v2/parts/BodyContent.jsx
+++ b/src/components/modal/v2/parts/BodyContent.jsx
@@ -75,6 +75,7 @@ const BodyContent = () => {
         document.documentElement.className = `${documentClassName} v5Design`;
     }
     const isPreapproved = productMeta?.preapproved;
+    const shouldShowPreapprovedBadge = productMeta?.showPreapprovedBadge;
     const preapprovalHeadline = content?.preapproval?.preapprovalHeadline;
     const preapprovalSubHeadline = content?.preapproval?.preapprovalSubHeadline;
     const preapprovalLabel = content?.preapproval?.preapprovalLabel;
@@ -154,6 +155,7 @@ const BodyContent = () => {
                     preapprovalLabel={preapprovalLabel}
                     // toggles preapproval content
                     isPreapproved={isPreapproved ?? 'false'}
+                    shouldShowPreapprovedBadge={shouldShowPreapprovedBadge ?? 'false'}
                 />
             ) : (
                 <Header

--- a/src/components/modal/v2/parts/CheckoutHeader.jsx
+++ b/src/components/modal/v2/parts/CheckoutHeader.jsx
@@ -13,7 +13,8 @@ const CheckoutHeader = ({
     preapprovalHeadline,
     preapprovalSubHeadline,
     preapprovalLabel,
-    isPreapproved = 'false'
+    isPreapproved = 'false',
+    shouldShowPreapprovedBadge = 'false'
 }) => {
     const { country } = useServerData();
     const [, handleClose] = useTransitionState();
@@ -32,6 +33,9 @@ const CheckoutHeader = ({
 
     // Used to specifically target styles to a specific country
     const countryClassName = country?.toLowerCase();
+
+    // Only show preapproved badge if user is preapproved AND in the treatment group
+    const showBadge = isPreapproved === 'true' && shouldShowPreapprovedBadge === 'true';
 
     // IMPORTANT: These elements cannot be nested inside of other elements.
     // They are using very precise CSS position sticky rules that require this
@@ -72,14 +76,12 @@ const CheckoutHeader = ({
                         // id used for aria-labelleby on modal container element
                         id="header__headline"
                         className={
-                            isPreapproved === 'true'
-                                ? `headline-${countryClassName}-preapproved`
-                                : `headline-${countryClassName}`
+                            showBadge ? `headline-${countryClassName}-preapproved` : `headline-${countryClassName}`
                         }
                         // eslint-disable-next-line react/no-danger
-                        dangerouslySetInnerHTML={{ __html: isPreapproved === 'true' ? preapprovalHeadline : headline }}
+                        dangerouslySetInnerHTML={{ __html: showBadge ? preapprovalHeadline : headline }}
                     />
-                    {isPreapproved === 'true' ? (
+                    {showBadge ? (
                         <span className={`preapproved-label ${countryClassName}`}>{preapprovalLabel}</span>
                     ) : (
                         ''
@@ -87,17 +89,14 @@ const CheckoutHeader = ({
                 </div>
                 {isQualifying === 'true' && qualifyingSubheadline !== '' ? (
                     <p className={`subheadline_p subheadline-${countryClassName} qualifying checkout`}>
-                        {isPreapproved === 'true'
-                            ? preapprovalSubHeadline
-                            : qualifyingSubheadline.replace(/(\s?EUR)/g, ' €')}
+                        {showBadge ? preapprovalSubHeadline : qualifyingSubheadline.replace(/(\s?EUR)/g, ' €')}
                     </p>
                 ) : (
                     <p
                         className={`subheadline_p subheadline-${countryClassName} checkout`}
                         // eslint-disable-next-line react/no-danger
                         dangerouslySetInnerHTML={{
-                            __html:
-                                currencyFormat(isPreapproved === 'true' ? preapprovalSubHeadline : subheadline) ?? ''
+                            __html: currencyFormat(showBadge ? preapprovalSubHeadline : subheadline) ?? ''
                         }}
                     />
                 )}

--- a/src/components/modal/v2/parts/CheckoutHeader.jsx
+++ b/src/components/modal/v2/parts/CheckoutHeader.jsx
@@ -35,7 +35,7 @@ const CheckoutHeader = ({
     const countryClassName = country?.toLowerCase();
 
     // Only show preapproved badge if user is preapproved AND in the treatment group
-    const showBadge = isPreapproved === 'true' && shouldShowPreapprovedBadge === 'true';
+    const showPreapprovalContent = isPreapproved === 'true' && shouldShowPreapprovedBadge === 'true';
 
     // IMPORTANT: These elements cannot be nested inside of other elements.
     // They are using very precise CSS position sticky rules that require this
@@ -76,12 +76,14 @@ const CheckoutHeader = ({
                         // id used for aria-labelleby on modal container element
                         id="header__headline"
                         className={
-                            showBadge ? `headline-${countryClassName}-preapproved` : `headline-${countryClassName}`
+                            showPreapprovalContent
+                                ? `headline-${countryClassName}-preapproved`
+                                : `headline-${countryClassName}`
                         }
                         // eslint-disable-next-line react/no-danger
-                        dangerouslySetInnerHTML={{ __html: showBadge ? preapprovalHeadline : headline }}
+                        dangerouslySetInnerHTML={{ __html: showPreapprovalContent ? preapprovalHeadline : headline }}
                     />
-                    {showBadge ? (
+                    {showPreapprovalContent ? (
                         <span className={`preapproved-label ${countryClassName}`}>{preapprovalLabel}</span>
                     ) : (
                         ''
@@ -89,14 +91,16 @@ const CheckoutHeader = ({
                 </div>
                 {isQualifying === 'true' && qualifyingSubheadline !== '' ? (
                     <p className={`subheadline_p subheadline-${countryClassName} qualifying checkout`}>
-                        {showBadge ? preapprovalSubHeadline : qualifyingSubheadline.replace(/(\s?EUR)/g, ' €')}
+                        {showPreapprovalContent
+                            ? preapprovalSubHeadline
+                            : qualifyingSubheadline.replace(/(\s?EUR)/g, ' €')}
                     </p>
                 ) : (
                     <p
                         className={`subheadline_p subheadline-${countryClassName} checkout`}
                         // eslint-disable-next-line react/no-danger
                         dangerouslySetInnerHTML={{
-                            __html: currencyFormat(showBadge ? preapprovalSubHeadline : subheadline) ?? ''
+                            __html: currencyFormat(showPreapprovalContent ? preapprovalSubHeadline : subheadline) ?? ''
                         }}
                     />
                 )}

--- a/src/components/modal/v2/parts/views/ShortTerm/Content.jsx
+++ b/src/components/modal/v2/parts/views/ShortTerm/Content.jsx
@@ -24,7 +24,7 @@ export const ShortTerm = ({
         learnMoreLink,
         cta
     },
-    productMeta: { qualifying, periodicPayment, useV4Design, useV5Design, preapproved },
+    productMeta: { qualifying, periodicPayment, useV4Design, useV5Design, preapproved, showPreapprovedBadge },
     openProductList,
     useNewCheckoutDesign,
     use5Dot1Design
@@ -35,6 +35,8 @@ export const ShortTerm = ({
     const isQualifying = qualifying === 'true';
 
     const isPreapproved = preapproved === 'true';
+    const shouldShowPreapprovedBadge = showPreapprovedBadge === 'true';
+    const showPreapprovalContent = isPreapproved && shouldShowPreapprovedBadge;
 
     const preapprovalDisclaimerHeadline = preapproval?.preapprovalDisclaimerHeadline;
     const preapprovalDisclaimerBody = preapproval?.preapprovalDisclaimerBody;
@@ -143,7 +145,7 @@ export const ShortTerm = ({
                                 ))}
                             </div>
                         </div>
-                        {isPreapproved && (
+                        {showPreapprovalContent && (
                             <PreapprovalDisclaimer
                                 preapprovalDisclaimerBody={preapprovalDisclaimerBody}
                                 preapprovalDisclaimerHeadline={preapprovalDisclaimerHeadline}


### PR DESCRIPTION
Added ELMO treatment group routing support in `paypal-messaging-components` and `upstream-message-content` 

This will enable the pre-approval modal gating for US and GB experiments
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->

## Screenshots

### ELMO Implementation

<img width="1506" height="897" alt="UK-preapproval-control-group" src="https://github.com/user-attachments/assets/e587144d-45aa-42e4-a791-58dc1e159fb4" />
<img width="1509" height="902" alt="UK-preapproval-treatment-group" src="https://github.com/user-attachments/assets/fb41cfea-00fe-412a-b6c4-1cee605dfb10" />


<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
