### PR TITLE
fix: align treatments iframe namespace/device id for sticky assignment

### DIFF
--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -13,7 +13,8 @@ import {
     updateStorage,
     getDisableSetCookie,
     getFeatures,
-    getDefaultNamespace
+    getNamespace,
+    getOrCreateDeviceID
 } from '../../../utils/sdk';
 import { getGlobalUrl, createGlobalVariableGetter, globalEvent } from '../../../utils/global';
 import { ppDebug } from '../../../utils/debug';
@@ -61,7 +62,12 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
             namespace: {
                 type: 'string',
                 queryParam: false,
-                value: getDefaultNamespace
+                value: getNamespace
+            },
+            deviceID: {
+                type: 'string',
+                queryParam: false,
+                value: getOrCreateDeviceID
             },
 
             onReady: {

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -19,8 +19,11 @@ describe('treatments component', () => {
 
     test('handles treatment data', () => {
         const {
-            props: { onReady }
+            props: { onReady, namespace, deviceID: canonicalDeviceID }
         } = getTreatmentsComponent();
+
+        expect(namespace).toBe(getNamespace());
+        expect(canonicalDeviceID).toEqual(expect.any(String));
 
         onReady({
             treatmentsHash,


### PR DESCRIPTION
## Description

This PR fixes a device ID mismatch path in v5 targeted messaging when treatments are fetched through the hidden treatments iframe.

### What problem this solves

We investigated reports in `DTCRCMERC-4514` and `DTCRCMERC-4676` where one device ID appeared across multiple treatments.

The key risk in the current code path was:
- Treatments iframe namespace used `getDefaultNamespace()`.
- Main message render/storage path used runtime `getNamespace()`.
- In custom-namespace scenarios, these can point to different storage keys.

That mismatch can cause treatments lookup and render-time device identity to drift.

### What changed

1. Treatments iframe now uses runtime namespace
- Updated treatments component to pass `namespace` with `getNamespace()` instead of `getDefaultNamespace()`.

2. Treatments iframe now receives canonical device ID from parent
- Added `deviceID` prop on treatments component using `getOrCreateDeviceID()`.

This keeps the treatments iframe aligned with the same namespace + device identity path used by message render.

### Why this is safe

- Scope is limited to treatments iframe props in messaging component.
- No public API shape changes for merchants.
- Existing treatment persistence behavior remains intact.

### Supporting evidence

- Jira: `DTCRCMERC-4514` (detailed investigation comments), `DTCRCMERC-4676` (follow-up), `DTCRCMERC-4410` (related stitching/session changes)
- Confluence:
  - v5 Targeted Messaging - Stitching Mechanism Spike
  - Stitching Messaging and Button events in PPCP Web SDK v5
- Both docs call out namespace and first-render/storage consistency edge cases.

## Screenshots / Videos

N/A

## Testing instructions

Run:

```bash
npm test -- --runInBand tests/unit/spec/src/zoid/treatments/component.test.js
npx eslint src/library/zoid/treatments/component.js tests/unit/spec/src/zoid/treatments/component.test.js
```

Expected:
- Unit test passes.
- ESLint passes.

### Verification completed in this branch

- `npm test -- --runInBand tests/unit/spec/src/zoid/treatments/component.test.js` ✅
- `npx eslint src/library/zoid/treatments/component.js tests/unit/spec/src/zoid/treatments/component.test.js` ✅

## Review

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

- Code follows team standards and best practices
- Changes are thoroughly tested and verified
- The PR template is filled out
- Documentation is complete and accurate
- The PR is ready for official code owner review

Once you have received initial approval, please do the following:

- Remove the label `Needs initial review`
- Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
