### PR TITLE
fix: mitigate multi-treatment symptoms with request-scoped deviceID metadata

### DIFF
--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -273,9 +273,9 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                 global: {
                                     ...existingGlobal,
                                     ts: tsCookie,
-                                    // deviceID from internal iframe storage
-                                    // should be populated previously by the treatments component
-                                    deviceID: getOrCreateDeviceID(),
+                                    // Prefer the request-scoped deviceID so logging stays aligned
+                                    // with the same identifier used in this message request.
+                                    deviceID: props.deviceID || getOrCreateDeviceID(),
                                     // Session ID from parent local storage,
                                     sessionID: getSessionID(),
                                     globalSessionID

--- a/src/library/zoid/modal/component.js
+++ b/src/library/zoid/modal/component.js
@@ -325,8 +325,9 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                                 global: {
                                     ...existingGlobal,
                                     ts: tsCookie,
-                                    // Device ID should be correctly set during message render
-                                    deviceID: getOrCreateDeviceID(),
+                                    // Prefer request-scoped deviceID to keep logging consistent
+                                    // with the same identifier used by this modal request.
+                                    deviceID: props.deviceID || getOrCreateDeviceID(),
                                     sessionID: getSessionID()
                                 },
                                 [index]: {

--- a/tests/unit/spec/src/zoid/deviceIDMeta.test.js
+++ b/tests/unit/spec/src/zoid/deviceIDMeta.test.js
@@ -1,0 +1,141 @@
+import getMessageComponent from 'src/library/zoid/message/component';
+import getModalComponent from 'src/library/zoid/modal/component';
+import { logger, getOrCreateDeviceID } from 'src/utils';
+import { destroyGlobalState } from 'src/utils/global';
+
+jest.mock('@krakenjs/zoid/src', () => ({
+    create: config => config
+}));
+
+jest.mock('src/utils', () => {
+    const actual = jest.requireActual('src/utils');
+    return {
+        ...actual,
+        logger: {
+            addMetaBuilder: jest.fn(),
+            track: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn()
+        },
+        runStats: jest.fn(),
+        updateStorage: jest.fn(),
+        getCurrentTime: jest.fn(() => 5000),
+        getTsCookieFromStorage: jest.fn(() => ({ vr: 'vr-cookie', vt: 'vt-cookie' })),
+        getOrCreateDeviceID: jest.fn(() => 'storage-device-id'),
+        getSessionID: jest.fn(() => 'session-id'),
+        getScriptAttributes: jest.fn(() => ({})),
+        getPerformanceMeasure: jest.fn(() => 25)
+    };
+});
+
+const buildMessageReady = ({ deviceID } = {}) => {
+    const messageConfig = getMessageComponent();
+    const messageProps = {
+        account: 'client-id:test-client-id',
+        index: '1',
+        pageType: 'home',
+        deviceID,
+        modal: { updateProps: jest.fn() },
+        getContainer: () => document.createElement('div'),
+        onReady: jest.fn()
+    };
+
+    const onReady = messageConfig.props.onReady.value({ props: messageProps });
+    onReady({
+        meta: {
+            offerType: 'PAY_LATER',
+            ppDebugId: 'debug-id',
+            trackingDetails: {}
+        },
+        activeTags: [],
+        ts: { vr: 'vr', vt: 'vt' },
+        requestDuration: 42,
+        messageRequestId: 'message-request-id',
+        globalSessionID: 'global-session-id'
+    });
+
+    return logger.addMetaBuilder.mock.calls[0][0];
+};
+
+const buildModalReady = ({ deviceID } = {}) => {
+    const modalConfig = getModalComponent();
+    const modalProps = {
+        account: 'client-id:test-client-id',
+        index: '2',
+        offer: 'PAY_LATER',
+        refIndex: '1',
+        buttonSessionId: 'button-session-id',
+        messageRequestId: 'message-request-id',
+        deviceID,
+        onReady: jest.fn()
+    };
+    const modalState = {
+        renderStart: 4000,
+        show: jest.fn(),
+        hide: jest.fn()
+    };
+    const event = {
+        trigger: jest.fn()
+    };
+
+    const onReady = modalConfig.props.onReady.value({ props: modalProps, state: modalState, event });
+    onReady({
+        products: ['PAY_LATER'],
+        meta: {
+            ppDebugId: 'debug-id',
+            trackingDetails: {}
+        },
+        ts: { vr: 'vr', vt: 'vt' }
+    });
+
+    return logger.addMetaBuilder.mock.calls[0][0];
+};
+
+describe('request-scoped deviceID logger metadata', () => {
+    beforeEach(() => {
+        logger.addMetaBuilder.mockClear();
+        logger.track.mockClear();
+        logger.info.mockClear();
+        logger.warn.mockClear();
+        getOrCreateDeviceID.mockClear();
+        destroyGlobalState();
+    });
+
+    afterAll(() => {
+        destroyGlobalState();
+    });
+
+    test('message metadata uses request-scoped deviceID when present', () => {
+        const buildMeta = buildMessageReady({ deviceID: 'message-request-device-id' });
+        const callsBeforeMetaBuild = getOrCreateDeviceID.mock.calls.length;
+        const meta = buildMeta({ global: { existing: true } });
+
+        expect(meta.global.deviceID).toBe('message-request-device-id');
+        expect(getOrCreateDeviceID.mock.calls.length).toBe(callsBeforeMetaBuild);
+    });
+
+    test('message metadata falls back to storage deviceID when request-scoped deviceID is missing', () => {
+        const buildMeta = buildMessageReady();
+        const callsBeforeMetaBuild = getOrCreateDeviceID.mock.calls.length;
+        const meta = buildMeta({ global: {} });
+
+        expect(meta.global.deviceID).toBe('storage-device-id');
+        expect(getOrCreateDeviceID.mock.calls.length).toBe(callsBeforeMetaBuild + 1);
+    });
+
+    test('modal metadata uses request-scoped deviceID when present', () => {
+        const buildMeta = buildModalReady({ deviceID: 'modal-request-device-id' });
+        const meta = buildMeta({ global: { existing: true } });
+
+        expect(meta.global.deviceID).toBe('modal-request-device-id');
+        expect(getOrCreateDeviceID).not.toHaveBeenCalled();
+    });
+
+    test('modal metadata falls back to storage deviceID when request-scoped deviceID is missing', () => {
+        const buildMeta = buildModalReady();
+        const meta = buildMeta({ global: {} });
+
+        expect(meta.global.deviceID).toBe('storage-device-id');
+        expect(getOrCreateDeviceID).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Description

This PR scopes PMCs to a **symptom fix** for DTCRCMERC-4676 (Device ID showing up in multiple treatments).

Problem observed:
- A single Device ID can appear under multiple treatment paths in downstream analysis.
- In PMCs, logger metadata could read `deviceID` from mutable local storage after cross-component updates.

What this PR changes:
- In message and modal logger meta builders, prefer request-scoped `props.deviceID`.
- Only fall back to `getOrCreateDeviceID()` when request-scoped `deviceID` is missing.

Why this is scoped to symptoms:
- This change stabilizes attribution/logging consistency per request.
- It does **not** change treatment assignment logic or bucketing logic.

Complementary aid:
- CPNW stale treatment hash replay mitigation (complementary server-side aid): https://github.paypal.com/Credit-R/crcpresentmentnodeweb/pull/893

## Screenshots / Videos

N/A

## Testing instructions

From this branch:

- `npm run lint -- src/library/zoid/message/component.js src/library/zoid/modal/component.js tests/unit/spec/src/zoid/deviceIDMeta.test.js`
- `npm test -- tests/unit/spec/src/zoid/deviceIDMeta.test.js --runInBand`

What to verify:
- Request-scoped `deviceID` is used in message/modal logger metadata when present.
- Storage fallback still works when request-scoped `deviceID` is absent.
- No treatment assignment logic changes in PMCs.

## Review

The expected SLA for reviews in this repo is 3 days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
