### PR TITLE
feat: Add language_rendered field to fpti

### DIFF
--- a/src/library/zoid/message/component.js
+++ b/src/library/zoid/message/component.js
@@ -242,7 +242,7 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                     const { onReady } = props;
                     return ({ meta, activeTags, ts, requestDuration, messageRequestId, globalSessionID }) => {
                         const { account, merchantId, index, modal, getContainer, pageType, language, locale } = props;
-                        const { trackingDetails, offerType, ppDebugId } = meta;
+                        const { trackingDetails, offerType, ppDebugId, language: renderedLanguage } = meta;
                         const partnerClientId = merchantId && account.slice(10); // slice is to remove the characters 'client-id:' from account name
 
                         // overwrites potentially poisoned PAGE_TYPE value from cached trackingDetails
@@ -286,7 +286,8 @@ export default createGlobalVariableGetter('__paypal_credit_message__', () =>
                                     account: merchantId || account,
                                     partnerClientId,
                                     trackingDetails,
-                                    language_requested: locale?.replace('_', '-') || language
+                                    language_requested: locale?.replace('_', '-') || language,
+                                    language_rendered: renderedLanguage ?? 'undefined'
                                 }
                             };
                         });

--- a/src/library/zoid/modal/component.js
+++ b/src/library/zoid/modal/component.js
@@ -303,7 +303,7 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                         const { index, offer, merchantId, account, refIndex, messageRequestId, language, locale } =
                             props;
                         const { renderStart, show, hide } = state;
-                        const { trackingDetails, ppDebugId } = meta;
+                        const { trackingDetails, ppDebugId, language: renderedLanguage } = meta;
                         const partnerClientId = merchantId && account.slice(10); // slice is to remove the characters 'client-id:' from account name
 
                         ppDebug(`Modal Correlation ID: ${ppDebugId}`);
@@ -336,7 +336,8 @@ export default createGlobalVariableGetter('__paypal_credit_modal__', () =>
                                     account: merchantId || account,
                                     partnerClientId,
                                     trackingDetails,
-                                    language_requested: locale?.replace('_', '-') || language
+                                    language_requested: locale?.replace('_', '-') || language,
+                                    language_rendered: renderedLanguage ?? 'undefined'
                                 }
                             };
                         });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -34,7 +34,8 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
                 messageRequestId,
                 stats = {},
                 trackingDetails,
-                language_requested
+                language_requested,
+                language_rendered
             } = component;
             const { clickUrl } = trackingDetails;
             delete trackingDetails.clickUrl;
@@ -70,6 +71,7 @@ function generateLogPayload(account, { meta, events: bizEvents, tracking }) {
                 button_session_id: buttonSessionId,
                 fdata,
                 language_requested: language_requested ?? 'undefined',
+                language_rendered: language_rendered ?? 'undefined',
                 merchant_events: bizEvents.filter(event => event.payload?.index === index),
                 ...trackingDetails,
                 ...stats,


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->


## Description




- Added `language_rendered` tracking field to message and modal components
- Captures `meta.language` from server response to track the actual language _rendered_ vs. what was _requested_ (`language_requested`)
- Currently only CA (Canada) locale returns `meta.language` from the backend; other locales will show `'undefined'` until backend rolls out support


<!-- Describe your changes and what problem they solve -->

## Screenshots / Videos

<!-- Add any relevant screenshots, GIFs, or a short video demo. For non-UI changes, write "N/A". -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
