### PR TITLE
refactor: add buttons zoid component in TAG

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,5 +10,7 @@ export const OFFER = {
 export const TAG = {
     MESSAGE: 'paypal-message',
     MODAL: 'paypal-credit-modal',
-    TREATEMENTS: 'paypal-credit-treatments'
+    TREATEMENTS: 'paypal-credit-treatments',
+    // Prevent messaging treatments from running inside buttons iframe (avoids duplicate /experiments/local + /hash)
+    BUTTONS: 'paypal-buttons'
 };

--- a/tests/unit/spec/src/controllers/message/setup.test.js
+++ b/tests/unit/spec/src/controllers/message/setup.test.js
@@ -23,7 +23,18 @@ jest.mock('src/utils/experiments', () => {
 });
 
 describe('message setup', () => {
+    let originalWindowName;
+    let ensureTreatmentsMock;
+
+    beforeEach(() => {
+        originalWindowName = window.name;
+        // eslint-disable-next-line global-require
+        ensureTreatmentsMock = require('src/utils/experiments').ensureTreatments;
+        ensureTreatmentsMock.mockReset();
+    });
+
     afterEach(() => {
+        window.name = originalWindowName;
         Messages.mockClear();
         Messages().render.mockClear();
         destroy();
@@ -55,6 +66,18 @@ describe('message setup', () => {
 
         setup();
 
+        expect(Messages().render).not.toHaveBeenCalled();
+
+        removeMockScript();
+    });
+
+    test('Does not run treatments or auto-render in buttons zoid iframe', () => {
+        const removeMockScript = insertMockScript({ account: 'DEV00000000NI' });
+        window.name = '__zoid__paypal_buttons__test';
+
+        setup();
+
+        expect(ensureTreatmentsMock).not.toHaveBeenCalled();
         expect(Messages().render).not.toHaveBeenCalled();
 
         removeMockScript();


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->
When SDK is loaded with components=messages,buttons, the buttons iframe also loads messaging. That causes treatments to run in the paypal.com iframe and duplicate local/hash calls. so

 Add TAG.BUTTONS = 'paypal-buttons' so isZoidComponent() treats the buttons iframe as zoid and skips ensureTreatments() there. This prevents duplicate /experiments/local + /hash calls coming from the buttons iframe, while keeping the standard ensureTreatments() behavior the same.
 

## Screenshots / Videos

<!-- Add any relevant screenshots, GIFs, or a short video demo. For non-UI changes, write "N/A". -->


https://github.com/user-attachments/assets/df909f64-33ef-4fdd-9ba8-d001455964f8



## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
Test on sdk demo page calling out `components=messages,buttons` 
stageTag: `op_button_deviceid_00`

 In DevTools:
      - Confirm  message and buttons render.
      - In Network, confirm single /experiments/local and /experiments/hash on load.
      - Confirm no extra treatments calls from the buttons iframe.
      - Verify in the Applications Tab, the merchants domain has the treatmenthash but verify paypal localStorage does not. 
## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
