### PR TITLE
feat: send client_id with treatments iframe

### DIFF
--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -38,16 +38,6 @@ function getTreatmentClientId() {
     return account?.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account.slice(CLIENT_ID_ACCOUNT_PREFIX.length) : undefined;
 }
 
-function getTreatmentPayerId() {
-    if (__MESSAGES__.__TARGET__ === 'SDK') {
-        return undefined;
-    }
-
-    const account = getGlobalConfigAccount();
-
-    return account && !account.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account : undefined;
-}
-
 export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
     create({
         tag: TAG.TREATEMENTS,
@@ -103,12 +93,6 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                 queryParam: 'client_id',
                 required: false,
                 value: getTreatmentClientId
-            },
-            payerId: {
-                type: 'string',
-                queryParam: 'payer_id',
-                required: false,
-                value: getTreatmentPayerId
             },
 
             onReady: {

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -17,8 +17,36 @@ import {
     getDefaultNamespace,
     getClientId
 } from '../../../utils/sdk';
-import { getGlobalUrl, createGlobalVariableGetter, globalEvent } from '../../../utils/global';
+import { getGlobalUrl, createGlobalVariableGetter, globalEvent, getGlobalState } from '../../../utils/global';
 import { ppDebug } from '../../../utils/debug';
+
+const CLIENT_ID_ACCOUNT_PREFIX = 'client-id:';
+
+function getGlobalConfigAccount() {
+    const { account } = getGlobalState().config;
+
+    return typeof account === 'string' ? account : undefined;
+}
+
+function getTreatmentClientId() {
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        return getClientId();
+    }
+
+    const account = getGlobalConfigAccount();
+
+    return account?.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account.slice(CLIENT_ID_ACCOUNT_PREFIX.length) : undefined;
+}
+
+function getTreatmentPayerId() {
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        return undefined;
+    }
+
+    const account = getGlobalConfigAccount();
+
+    return account && !account.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account : undefined;
+}
 
 export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
     create({
@@ -74,7 +102,13 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                 type: 'string',
                 queryParam: 'client_id',
                 required: false,
-                value: getClientId
+                value: getTreatmentClientId
+            },
+            payerId: {
+                type: 'string',
+                queryParam: 'payer_id',
+                required: false,
+                value: getTreatmentPayerId
             },
 
             onReady: {

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -14,7 +14,8 @@ import {
     updateStorage,
     getDisableSetCookie,
     getFeatures,
-    getDefaultNamespace
+    getDefaultNamespace,
+    getClientId
 } from '../../../utils/sdk';
 import { getGlobalUrl, createGlobalVariableGetter, globalEvent } from '../../../utils/global';
 import { ppDebug } from '../../../utils/debug';
@@ -68,6 +69,12 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                 type: 'string',
                 queryParam: true,
                 value: getOrCreateDeviceID
+            },
+            clientId: {
+                type: 'string',
+                queryParam: 'client_id',
+                required: false,
+                value: getClientId
             },
 
             onReady: {

--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -38,6 +38,16 @@ function getTreatmentClientId() {
     return account?.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account.slice(CLIENT_ID_ACCOUNT_PREFIX.length) : undefined;
 }
 
+function getTreatmentPayerId() {
+    if (__MESSAGES__.__TARGET__ === 'SDK') {
+        return undefined;
+    }
+
+    const account = getGlobalConfigAccount();
+
+    return account && !account.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account : undefined;
+}
+
 export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
     create({
         tag: TAG.TREATEMENTS,
@@ -93,6 +103,12 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                 queryParam: 'client_id',
                 required: false,
                 value: getTreatmentClientId
+            },
+            payerId: {
+                type: 'string',
+                queryParam: 'payer_id',
+                required: false,
+                value: getTreatmentPayerId
             },
 
             onReady: {

--- a/tests/unit/spec/src/utils/experiments.test.js
+++ b/tests/unit/spec/src/utils/experiments.test.js
@@ -21,6 +21,7 @@ jest.mock('../../../../../src/utils/functional', () => {
 });
 
 jest.mock('@paypal/sdk-client/src', () => ({
+    getClientID: () => 'client_id',
     getNamespace: () => 'paypal',
     getPayPalDomain: () => 'localhost.paypal.com',
     getSDKMeta: () => 'meta',

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -55,18 +55,13 @@ describe('treatments component', () => {
         expect(treatmentsComponent.props.deviceID).toBe('test-device-id');
     });
 
-    test('sends payer_id from global config for standalone payer account treatments', () => {
+    test('does not send experiment credentials for standalone payer account treatments', () => {
         window.__MESSAGES__.__TARGET__ = 'STANDALONE';
         setGlobalState({ config: { account: 'DEV00000000NI' } });
 
         const treatmentsComponent = getTreatmentsComponent();
 
-        expect(treatmentsComponent.config.props.payerId).toMatchObject({
-            type: 'string',
-            queryParam: 'payer_id',
-            required: false
-        });
-        expect(treatmentsComponent.props.payerId).toBe('DEV00000000NI');
+        expect(treatmentsComponent.config.props.payerId).toBeUndefined();
         expect(treatmentsComponent.props.clientId).toBeUndefined();
     });
 
@@ -77,7 +72,7 @@ describe('treatments component', () => {
         const treatmentsComponent = getTreatmentsComponent();
 
         expect(treatmentsComponent.props.clientId).toBe('test-standalone-client-id');
-        expect(treatmentsComponent.props.payerId).toBeUndefined();
+        expect(treatmentsComponent.config.props.payerId).toBeUndefined();
     });
 
     test('handles treatment data', () => {

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -3,6 +3,16 @@ import '../../../../utils/mockZoidCreate';
 import { getTreatmentsComponent } from '../../../../../../src/library/zoid/treatments';
 import { getNamespace, globalEvent } from '../../../../../../src/utils';
 
+jest.mock('@paypal/sdk-client/src', () => ({
+    getClientID: () => 'test-client-id',
+    getDefaultNamespace: () => 'paypal',
+    getDisableSetCookie: () => false,
+    getEnv: () => 'stage',
+    getPayPalDomain: () => 'https://www.paypal.com',
+    getSDKMeta: () => 'sdk-meta',
+    getStorageID: () => 'test-device-id'
+}));
+
 jest.mock('../../../../../../src/utils/global', () => {
     const global = jest.requireActual('../../../../../../src/utils/global');
     return {
@@ -15,6 +25,34 @@ jest.mock('../../../../../../src/utils/global', () => {
 
 describe('treatments component', () => {
     const treatmentsHash = '1daf92517fb7620b02add6943517ae0a5ca8f0a0';
+    let target;
+
+    beforeEach(() => {
+        target = window.__MESSAGES__.__TARGET__;
+    });
+
+    afterEach(() => {
+        window.__MESSAGES__.__TARGET__ = target;
+    });
+
+    test('sends client_id and deviceID query props for SDK treatments', () => {
+        window.__MESSAGES__.__TARGET__ = 'SDK';
+
+        const treatmentsComponent = getTreatmentsComponent();
+
+        expect(treatmentsComponent.config.props.clientId).toMatchObject({
+            type: 'string',
+            queryParam: 'client_id',
+            required: false
+        });
+        expect(treatmentsComponent.props.clientId).toBe('test-client-id');
+        expect(treatmentsComponent.config.props.deviceID).toMatchObject({
+            type: 'string',
+            queryParam: true
+        });
+        expect(treatmentsComponent.props.deviceID).toBe('test-device-id');
+    });
+
     test('handles treatment data', () => {
         const {
             props: { onReady }

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -48,6 +48,7 @@ describe('treatments component', () => {
             required: false
         });
         expect(treatmentsComponent.props.clientId).toBe('test-client-id');
+        expect(treatmentsComponent.props.payerId).toBeUndefined();
         expect(treatmentsComponent.config.props.deviceID).toMatchObject({
             type: 'string',
             queryParam: true
@@ -55,13 +56,18 @@ describe('treatments component', () => {
         expect(treatmentsComponent.props.deviceID).toBe('test-device-id');
     });
 
-    test('does not send experiment credentials for standalone payer account treatments', () => {
+    test('sends payer_id from global config for standalone payer account treatments', () => {
         window.__MESSAGES__.__TARGET__ = 'STANDALONE';
         setGlobalState({ config: { account: 'DEV00000000NI' } });
 
         const treatmentsComponent = getTreatmentsComponent();
 
-        expect(treatmentsComponent.config.props.payerId).toBeUndefined();
+        expect(treatmentsComponent.config.props.payerId).toMatchObject({
+            type: 'string',
+            queryParam: 'payer_id',
+            required: false
+        });
+        expect(treatmentsComponent.props.payerId).toBe('DEV00000000NI');
         expect(treatmentsComponent.props.clientId).toBeUndefined();
     });
 
@@ -72,7 +78,30 @@ describe('treatments component', () => {
         const treatmentsComponent = getTreatmentsComponent();
 
         expect(treatmentsComponent.props.clientId).toBe('test-standalone-client-id');
-        expect(treatmentsComponent.config.props.payerId).toBeUndefined();
+        expect(treatmentsComponent.props.payerId).toBeUndefined();
+    });
+
+    test.each([undefined, '', { payerId: 'DEV00000000NI' }])(
+        'does not send experiment credentials for standalone account %p',
+        account => {
+            window.__MESSAGES__.__TARGET__ = 'STANDALONE';
+            setGlobalState({ config: { account } });
+
+            const treatmentsComponent = getTreatmentsComponent();
+
+            expect(treatmentsComponent.props.clientId).toBeUndefined();
+            expect(treatmentsComponent.props.payerId).toBeUndefined();
+        }
+    );
+
+    test('prefers client_id when standalone account uses client-id prefix', () => {
+        window.__MESSAGES__.__TARGET__ = 'STANDALONE';
+        setGlobalState({ config: { account: 'client-id:test-client-id' } });
+
+        const treatmentsComponent = getTreatmentsComponent();
+
+        expect(treatmentsComponent.props.clientId).toBe('test-client-id');
+        expect(treatmentsComponent.props.payerId).toBeUndefined();
     });
 
     test('handles treatment data', () => {

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -1,7 +1,7 @@
 import '../../../../utils/mockZoidCreate';
 
 import { getTreatmentsComponent } from '../../../../../../src/library/zoid/treatments';
-import { getNamespace, globalEvent } from '../../../../../../src/utils';
+import { destroyGlobalState, getNamespace, globalEvent, setGlobalState } from '../../../../../../src/utils';
 
 jest.mock('@paypal/sdk-client/src', () => ({
     getClientID: () => 'test-client-id',
@@ -29,10 +29,12 @@ describe('treatments component', () => {
 
     beforeEach(() => {
         target = window.__MESSAGES__.__TARGET__;
+        destroyGlobalState();
     });
 
     afterEach(() => {
         window.__MESSAGES__.__TARGET__ = target;
+        destroyGlobalState();
     });
 
     test('sends client_id and deviceID query props for SDK treatments', () => {
@@ -51,6 +53,31 @@ describe('treatments component', () => {
             queryParam: true
         });
         expect(treatmentsComponent.props.deviceID).toBe('test-device-id');
+    });
+
+    test('sends payer_id from global config for standalone payer account treatments', () => {
+        window.__MESSAGES__.__TARGET__ = 'STANDALONE';
+        setGlobalState({ config: { account: 'DEV00000000NI' } });
+
+        const treatmentsComponent = getTreatmentsComponent();
+
+        expect(treatmentsComponent.config.props.payerId).toMatchObject({
+            type: 'string',
+            queryParam: 'payer_id',
+            required: false
+        });
+        expect(treatmentsComponent.props.payerId).toBe('DEV00000000NI');
+        expect(treatmentsComponent.props.clientId).toBeUndefined();
+    });
+
+    test('sends client_id from global config for standalone client-id account treatments', () => {
+        window.__MESSAGES__.__TARGET__ = 'STANDALONE';
+        setGlobalState({ config: { account: 'client-id:test-standalone-client-id' } });
+
+        const treatmentsComponent = getTreatmentsComponent();
+
+        expect(treatmentsComponent.props.clientId).toBe('test-standalone-client-id');
+        expect(treatmentsComponent.props.payerId).toBeUndefined();
     });
 
     test('handles treatment data', () => {

--- a/tests/unit/utils/mockZoidCreate.js
+++ b/tests/unit/utils/mockZoidCreate.js
@@ -7,6 +7,7 @@ jest.mock('@krakenjs/zoid/src', () => {
         ...actual,
         create: config => {
             const mockComponent = {
+                config,
                 state: {},
                 close: jest.fn(),
                 focus: jest.fn(),


### PR DESCRIPTION
## Description

Adds the supported experiment credential to the hidden treatments iframe request while keeping the existing `deviceID` query param unchanged.

This is the PMC half of `DTCRCMERC-5162` / `LI-152850`. SDK integrations send the SDK `client-id` as `client_id`. Standalone integrations send `client_id` when account config is in `client-id:<id>` form. Standalone payer-account config sends `payer_id`, which matches the final CPNW experiment credential contract.

Release order: PMC can release before CPNW because current CPNW `develop` still bypasses `/experiments` auth/validation and ignores unknown extra query params. The related CPNW PR enforces the credential path after this client change is available.

Related CPNW PR: https://github.com/OnePayPal/crcpresentmentnodeweb/pull/929

## PMC to CPNW experiment flow

```mermaid
flowchart TD
  A["Merchant page loads PMC messaging.js"] --> B["PMC creates hidden treatments iframe"]
  B --> C{"Which credential does PMC have?"}
  C -->|"SDK client-id"| D["PMC sends client_id + deviceID"]
  C -->|"Standalone account = client-id:<id>"| D
  C -->|"Standalone payer account"| E["PMC sends payer_id + deviceID"]
  D --> F["CPNW /experiments/local"]
  E --> F
  F --> G["CPNW auth + validation accept client_id or payer_id"]
  G --> H["CPNW returns local treatments script"]
  H --> I{"deviceID available in xprops?"}
  I -->|"No"| J["Script closes with no treatments"]
  I -->|"Yes"| K["Script calls /experiments/hash with device_id and the same credential key"]
  K --> L{"device_id present on hash route?"}
  L -->|"No"| M["CPNW returns empty no-treatment response, no ELMO call"]
  L -->|"Yes"| N["CPNW gets treatment hash from ELMO"]
  N --> O["CPNW returns hash with up-treatments-hash cache tag"]
  O --> P["PMC receives treatment hash and renders eligible message/modal"]
```

Plain-English contract:

- PMC sends exactly one credential: `client_id` for SDK/client-id config, or `payer_id` for standalone payer-account config.
- CPNW accepts the same credential key on `/experiments/local` and forwards that same key to `/experiments/hash`.
- Missing `device_id` means no treatments; CPNW should not call ELMO or cache an empty hash response.

Edge readiness: `DTEDGEENG-15564` is accepted and `CHG109867546` is deployed, so this PR does not change Edge cache-key behavior.

## Screenshots / Videos

N/A - this is a request-shape change for the hidden treatments iframe.

## Testing instructions

Automated checks run on this branch:

```bash
source "$HOME/.nvm/nvm.sh" && nvm use 20
npm test -- --runTestsByPath tests/unit/spec/src/utils/experiments.test.js tests/unit/spec/src/zoid/treatments/component.test.js
npx prettier --check src/library/zoid/treatments/component.js tests/unit/spec/src/zoid/treatments/component.test.js
npm run lint
npm test
git diff --check
```

Automated proof:

- Focused Jest passed: `2 passed suites`, `12 passed tests`.
- Full Jest passed: `32 passed suites`, `248 passed`, `2 skipped`, `6 todo`.
- Prettier passed on the touched files.
- Lint passed with the repo's existing unrelated warnings in `src/components/modal/v2/lib/postMessage.js` and `src/components/modal/v2/parts/InlineLinks.jsx`.
- `git diff --check` passed.
- Unit tests verify SDK client ID is sent as `client_id`, standalone `client-id:<id>` sends only `client_id`, standalone payer-account config sends only `payer_id`, empty/non-string account config sends no experiment credential, and existing `deviceID` behavior remains unchanged.

## Live TE endpoint proof

Verified on 2026-05-21 against TE using the supplied cookies and the Stage US cross-border account from the Accounts for Testing page. Identifiers and cookies are redacted here.

| Probe | Result | Why it matters |
| --- | --- | --- |
| Original supplied `/experiments/local` curl with only `sdkMeta` | `403 paypal_messages_not_authorized` | Confirms `sdkMeta` is not the experiment auth credential; PMC must send an explicit query credential. |
| `/experiments/local?...&client_id=<redacted>` | `200`; generated script includes `client_id` and not `payer_id` | SDK/client-id path still works and carries the same credential key to the client script. |
| `/experiments/local?...&payer_id=<redacted cross-border account>` | `200`; generated script includes `payer_id` and not `client_id` | New standalone payer-account path works without needing a client id. |
| `/experiments/hash?device_id=<redacted>&client_id=<redacted>` | `200`; 40-byte hash body | Existing client-id hash path still returns a stable experiment hash. |
| `/experiments/hash?device_id=<redacted>&payer_id=<redacted cross-border account>` | `200`; 40-byte hash body | New payer-id hash path returns the same class of hash response as client id. |
| `/experiments/hash?client_id=<redacted>` with no `device_id` | `200`; empty body | Missing device id keeps the no-treatment contract: no invalid request and no ELMO/cache hash. |
| `/experiments/hash?payer_id=<redacted cross-border account>` with no `device_id` | `200`; empty body | Payer-id path preserves the same no-device no-treatment behavior. |
| `/experiments/hash?device_id=invalid%3C%3Edevice&client_id=<redacted>` | `400 INVALID_REQUEST` | Invalid device id is blocked by the validator. |
| `/experiments/hash?device_id=<redacted>&client_id=<redacted>&payer_id=invalid_payer` | `400 INVALID_REQUEST` | Invalid payer id is blocked when auth can pass through the valid client id. |
| `/experiments/local?...&client_id=<redacted>&payer_id=invalid_payer` | `400 INVALID_REQUEST` | The local endpoint applies the same validator rule before rendering the script. |

Notes:
- The invalid client-id-only and invalid payer-id-only live probes returned `403` because route auth runs before validator error shaping. Focused unit coverage verifies validator syntax rejection for both query keys.
- Full cookies, account identifiers, client IDs, and payer IDs are intentionally omitted from this PR body.

## Full browser StageTag proof

Verified on 2026-05-21 with Chrome + Playwright using the staged PMC bundle from this branch.

```text
Bundle command: npm run build -- -t dtcrcmerc5162_payerid_0521 -s te-cpnw-auth
Bundle ID: dtcrcmerc5162_payerid_0521
Bundle version: 1.83.0-dtcrcmerc5162-payerid.0521
Bundle script: https://cdn-dtcrcmerc5162_payerid_0521.static.engineering.dev.paypalinc.com/upstream/bizcomponents/stage/messaging.js
Browser page origin: https://localhost.paypal.com:8099
CPNW origin: https://www.te-cpnw-auth.qa.paypal.com
```

The browser proof loaded the staged `messaging.js`, set `window.__TEST_ENV__` to TE before script load, injected the TE auth cookies into Chrome, and used the Stage US cross-border account for the payer-id path. Chrome was launched with local-network-access checks disabled because the merchant proof page runs from localhost while the iframe targets TE; CPNW auth, validation, response status, cache headers, and hash body still came from the real TE endpoints.

| Browser flow | `/experiments/local` proof | `/experiments/hash` proof | Result |
| --- | --- | --- | --- |
| Standalone payer account | `200`, URL had `payer_id`, no `client_id`, `deviceID`, `integrationType=STANDALONE`, `stageTag=dtcrcmerc5162_payerid_0521`, cache tag `up-treatments-zoid` | `200`, URL had `device_id + payer_id`, no `client_id`, 40-byte hash body, cache tag `up-treatments-hash` | Passed; no `400`, no `403`, no failed experiment request |
| Standalone `client-id:<id>` account | `200`, URL had `client_id`, no `payer_id`, `deviceID`, `integrationType=STANDALONE`, `stageTag=dtcrcmerc5162_payerid_0521`, cache tag `up-treatments-zoid` | `200`, URL had `device_id + client_id`, no `payer_id`, 40-byte hash body, cache tag `up-treatments-hash` | Passed; no `400`, no `403`, no failed experiment request |

Additional browser assertions:
- The rendered message iframe received the experiment `treatments` hash on both flows.
- The payer-account message iframe carried `payer_id` and not `client_id`.
- The client-id message iframe carried `client_id` and not `payer_id`.
- Full cookies, account identifiers, client IDs, payer IDs, and device IDs are intentionally omitted from this PR body.

## Review

The expected SLA for reviews in this repo is 3 days. All pull requests require an initial review from the team followed by code owner approval.

