### PR TITLE
refactor: update deviceID in updateProps to use xprops deviceID and not getOrCreateDeviceID

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -7,7 +7,6 @@ import {
     createState,
     getRequestDuration,
     getTsCookieFromStorage,
-    getOrCreateDeviceID,
     getGlobalSessionID
 } from '../../utils';
 
@@ -132,6 +131,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     channel,
                     contextualComponents,
                     treatmentsHash,
+                    deviceID,
                     disableSetCookie,
                     features,
                     pageType
@@ -178,7 +178,7 @@ const Message = function ({ markup, meta, parentStyles, warnings }) {
                     merchant_config: merchantConfigHash,
                     channel,
                     contextual_components: contextualComponents,
-                    deviceID: getOrCreateDeviceID(),
+                    deviceID,
                     treatments: treatmentsHash,
                     disableSetCookie,
                     features,

--- a/tests/unit/spec/src/components/message/Message.test.js
+++ b/tests/unit/spec/src/components/message/Message.test.js
@@ -1,7 +1,7 @@
 import { getByText, fireEvent, queryByText } from '@testing-library/dom';
 
 import Message from 'src/components/message/Message';
-import { request, createState } from 'src/utils';
+import { request, createState, getOrCreateDeviceID } from 'src/utils';
 import xPropsMock from 'utils/xPropsMock';
 
 const ts = {
@@ -177,5 +177,31 @@ describe('Message', () => {
             requestDuration: 123,
             ts
         });
+    });
+
+    test('Prop update uses xprops.deviceID instead of getOrCreateDeviceID', async () => {
+        const MERCHANT_DEVICE_ID = 'uid_3ee89db893_mdm6mdu6mtk';
+        const PAYPAL_DEVICE_ID = 'uid_1521da4bd8_mtc6mjk6nti';
+
+        window.xprops.amount = 100;
+        window.xprops.deviceID = MERCHANT_DEVICE_ID;
+
+        const messageDocument = document.body.appendChild(Message(serverData));
+
+        expect(getByText(messageDocument, /test/i)).toBeInTheDocument();
+        expect(window.xprops.onReady).toHaveBeenCalledTimes(1);
+
+        getOrCreateDeviceID.mockReturnValue(PAYPAL_DEVICE_ID);
+
+        updateProps({ amount: 500 });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(request).toHaveBeenCalledTimes(1);
+
+        const requestUrl = request.mock.calls[0][1];
+
+        expect(requestUrl).toContain(`deviceID=${MERCHANT_DEVICE_ID}`);
+        expect(requestUrl).not.toContain(PAYPAL_DEVICE_ID);
     });
 });


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->
update message rerender to use xprops deviceid and not the function getOrCreateDeviceID, which can give a different deviceID, since rerender is not on the same iframe 

## Screenshots / Videos

<!-- Add any relevant screenshots, GIFs, or a short video demo. For non-UI changes, write "N/A". -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
