### PR TITLE
feat(DTCRCMERC-5257): add renderV2Message SSR module

### DIFF
--- a/scripts/preview-v2-render.js
+++ b/scripts/preview-v2-render.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Minimal local preview server for the renderV2Message SSR bundle.
+ * Fetches the stage CDN bundle, renders a sample message, and serves it in a browser.
+ *
+ * Usage:
+ *   node scripts/preview-v2-render.js [stageTag]
+ *   node scripts/preview-v2-render.js render_v2_msg
+ *
+ * Then open: http://localhost:3030
+ */
+
+const http = require('http');
+const https = require('https');
+
+const STAGE_TAG = process.argv[2] || 'render_v2_msg';
+const BUNDLE_URL = `https://cdn-${STAGE_TAG}.static.engineering.dev.paypalinc.com/upstream/bizcomponents/stage/renderV2Message.js`;
+const PORT = 3030;
+
+function fetchBundle(url) {
+    return new Promise((resolve, reject) => {
+        https
+            .get(url, res => {
+                if (res.statusCode !== 200) {
+                    reject(new Error(`HTTP ${res.statusCode}`));
+                    return;
+                }
+                const chunks = [];
+                res.on('data', c => chunks.push(c));
+                res.on('end', () => resolve(Buffer.concat(chunks).toString()));
+                res.on('error', reject);
+            })
+            .on('error', reject);
+    });
+}
+
+function evalBundle(code) {
+    const mod = { exports: {} };
+    // eslint-disable-next-line no-new-func
+    new Function('exports', 'module', 'require', code)(mod.exports, mod, require);
+    return mod.exports.renderV2Message || mod.exports;
+}
+
+// Simulated CPNS v2 content payloads (one per variant)
+const VARIANTS = [
+    {
+        label: 'Text layout — Pay Later headline',
+        style: { layout: 'text', logo: { type: 'primary', position: 'left' }, text: { color: 'black', size: 14 } },
+        v2Content: {
+            main_items: [
+                { type: 'text', content: 'Buy now, pay later' },
+                { type: 'text', content: ' with PayPal.' }
+            ],
+            action_items: [{ type: 'text', content: 'Learn more' }],
+            disclaimer_items: [{ type: 'text', content: 'Subject to credit approval.' }],
+            meta: { offerCountry: 'US' }
+        }
+    },
+    {
+        label: 'Text layout — no action items',
+        style: { layout: 'text', logo: { type: 'alternative', position: 'left' }, text: { color: 'black' } },
+        v2Content: {
+            main_items: [{ type: 'text', content: '4 interest-free payments of $25.00' }],
+            action_items: [],
+            disclaimer_items: [{ type: 'text', content: 'Pay in 4 available.' }],
+            meta: { offerCountry: 'US' }
+        }
+    },
+    {
+        label: 'Text layout — grayscale logo',
+        style: { layout: 'text', logo: { type: 'primary', position: 'left' }, text: { color: 'black' } },
+        v2Content: {
+            main_items: [
+                { type: 'text', content: 'Pay Later' },
+                { type: 'text', content: ' — 0% interest for 6 months' }
+            ],
+            action_items: [{ type: 'text', content: 'Learn more' }],
+            disclaimer_items: [],
+            meta: { offerCountry: 'US' }
+        }
+    }
+];
+
+async function buildPage(mod) {
+    const sections = VARIANTS.map(({ label, style, v2Content }) => {
+        const logs = [];
+        const addLog = msg => logs.push(msg);
+        const validStyle = mod.validateStyle(addLog, style);
+        const parentStyles = mod.getParentStyles(validStyle) || '';
+        const html = mod.render(
+            { style: validStyle, amount: 100, currency: 'USD', locale: 'en_US', buyerCountry: 'US' },
+            v2Content,
+            addLog
+        );
+        return `
+            <section>
+                <h2>${label}</h2>
+                <div class="preview-frame">
+                    <style>${parentStyles}</style>
+                    ${html}
+                </div>
+                ${logs.length ? `<pre class="logs">Logs: ${logs.join('\n')}</pre>` : ''}
+            </section>`;
+    }).join('\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>renderV2Message Preview — ${STAGE_TAG}</title>
+    <style>
+        body { font-family: sans-serif; max-width: 900px; margin: 40px auto; background: #f5f5f5; }
+        h1 { color: #003087; }
+        .meta { color: #666; font-size: 13px; margin-bottom: 30px; }
+        section { background: white; border-radius: 8px; padding: 24px; margin-bottom: 24px; box-shadow: 0 1px 4px rgba(0,0,0,.1); }
+        h2 { font-size: 14px; color: #555; margin: 0 0 16px; }
+        .preview-frame { border: 1px dashed #ddd; border-radius: 4px; padding: 16px; background: #fff; width: 400px; }
+        .logs { font-size: 11px; color: #c00; margin-top: 12px; background: #fff5f5; padding: 8px; border-radius: 4px; }
+        .bundle-info { background: #e8f4e8; padding: 12px 16px; border-radius: 6px; font-size: 13px; margin-bottom: 24px; }
+    </style>
+</head>
+<body>
+    <h1>renderV2Message SSR Preview</h1>
+    <div class="bundle-info">
+        Bundle: <strong>${BUNDLE_URL}</strong><br>
+        Version: <strong>${mod.version}</strong>
+    </div>
+    ${sections}
+</body>
+</html>`;
+}
+
+async function main() {
+    console.log(`Fetching bundle from CDN (${STAGE_TAG})...`);
+    const code = await fetchBundle(BUNDLE_URL);
+    const mod = evalBundle(code);
+    console.log(`Bundle loaded — version: ${mod.version}`);
+
+    const server = http.createServer(async (req, res) => {
+        const page = await buildPage(mod);
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(page);
+    });
+
+    server.listen(PORT, () => {
+        console.log(`\n  Preview ready → http://localhost:${PORT}\n`);
+    });
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/preview-v2-render.js
+++ b/scripts/preview-v2-render.js
@@ -42,55 +42,112 @@ function evalBundle(code) {
     return mod.exports.renderV2Message || mod.exports;
 }
 
-// Simulated CPNS v2 content payloads (one per variant)
+function extractPreferredContent(response) {
+    return response?.messages?.[0]?.preferred_message?.content || {};
+}
+
+// Simulated v2 API responses (one per variant)
 const VARIANTS = [
     {
-        label: 'Text layout — Pay Later headline',
+        label: 'Text layout — logo + Pay Later headline',
         style: { layout: 'text', logo: { type: 'primary', position: 'left' }, text: { color: 'black', size: 14 } },
-        v2Content: {
-            main_items: [
-                { type: 'text', content: 'Buy now, pay later' },
-                { type: 'text', content: ' with PayPal.' }
-            ],
-            action_items: [{ type: 'text', content: 'Learn more' }],
-            disclaimer_items: [{ type: 'text', content: 'Subject to credit approval.' }],
-            meta: { offerCountry: 'US' }
+        v2Response: {
+            messages: [
+                {
+                    preferred_message: {
+                        content: {
+                            main_items: [
+                                {
+                                    type: 'IMAGE',
+                                    name: 'paypal_logo',
+                                    source_url:
+                                        'https://www.paypalobjects.com/upstream/assets/logos/v2/paypal_wordmark.svg',
+                                    alternative_text: 'PayPal'
+                                },
+                                { type: 'TEXT', text: 'Buy now, pay later.' }
+                            ],
+                            action_items: [
+                                {
+                                    type: 'LINK',
+                                    text: 'Learn more',
+                                    click_url: 'https://www.paypal.com/credit-presentment/lander',
+                                    embeddable: true
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
     },
     {
         label: 'Text layout — no action items',
         style: { layout: 'text', logo: { type: 'alternative', position: 'left' }, text: { color: 'black' } },
-        v2Content: {
-            main_items: [{ type: 'text', content: '4 interest-free payments of $25.00' }],
-            action_items: [],
-            disclaimer_items: [{ type: 'text', content: 'Pay in 4 available.' }],
-            meta: { offerCountry: 'US' }
+        v2Response: {
+            messages: [
+                {
+                    preferred_message: {
+                        content: {
+                            main_items: [
+                                {
+                                    type: 'IMAGE',
+                                    name: 'paypal_logo',
+                                    source_url:
+                                        'https://www.paypalobjects.com/upstream/assets/logos/v2/paypal_wordmark.svg',
+                                    alternative_text: 'PayPal'
+                                },
+                                { type: 'TEXT', text: '4 interest-free payments of $25.00.' }
+                            ],
+                            action_items: []
+                        }
+                    }
+                }
+            ]
         }
     },
     {
-        label: 'Text layout — grayscale logo',
-        style: { layout: 'text', logo: { type: 'primary', position: 'left' }, text: { color: 'black' } },
-        v2Content: {
-            main_items: [
-                { type: 'text', content: 'Pay Later' },
-                { type: 'text', content: ' — 0% interest for 6 months' }
-            ],
-            action_items: [{ type: 'text', content: 'Learn more' }],
-            disclaimer_items: [],
-            meta: { offerCountry: 'US' }
+        label: 'Text layout — logo right',
+        style: { layout: 'text', logo: { type: 'primary', position: 'right' }, text: { color: 'black' } },
+        v2Response: {
+            messages: [
+                {
+                    preferred_message: {
+                        content: {
+                            main_items: [
+                                { type: 'TEXT', text: 'As low as $26.94/mo.' },
+                                {
+                                    type: 'IMAGE',
+                                    name: 'paypal_logo',
+                                    source_url:
+                                        'https://www.paypalobjects.com/upstream/assets/logos/v2/paypal_wordmark.svg',
+                                    alternative_text: 'PayPal'
+                                }
+                            ],
+                            action_items: [
+                                {
+                                    type: 'LINK',
+                                    text: 'Learn more',
+                                    click_url: 'https://www.paypal.com/credit-presentment/lander',
+                                    embeddable: true
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
     }
 ];
 
 async function buildPage(mod) {
-    const sections = VARIANTS.map(({ label, style, v2Content }) => {
+    const sections = VARIANTS.map(({ label, style, v2Response }) => {
         const logs = [];
         const addLog = msg => logs.push(msg);
         const validStyle = mod.validateStyle(addLog, style);
         const parentStyles = mod.getParentStyles(validStyle) || '';
         const html = mod.render(
             { style: validStyle, amount: 100, currency: 'USD', locale: 'en_US', buyerCountry: 'US' },
-            v2Content,
+            extractPreferredContent(v2Response),
             addLog
         );
         return `

--- a/scripts/smoke-test-v2-bundle.js
+++ b/scripts/smoke-test-v2-bundle.js
@@ -14,14 +14,33 @@ const https = require('https');
 const STAGE_TAG = process.argv[2] || 'render_v2_msg';
 const BUNDLE_URL = `https://cdn-${STAGE_TAG}.static.engineering.dev.paypalinc.com/upstream/bizcomponents/stage/renderV2Message.js`;
 
-const SAMPLE_V2_CONTENT = {
-    main_items: [
-        { type: 'text', content: 'Pay Later' },
-        { type: 'text', content: ' with PayPal.' }
-    ],
-    action_items: [{ type: 'text', content: 'Learn more' }],
-    disclaimer_items: [{ type: 'text', content: 'Subject to credit approval.' }],
-    meta: { offerCountry: 'US' }
+const SAMPLE_V2_RESPONSE = {
+    messages: [
+        {
+            preferred_message: {
+                content: {
+                    main_items: [
+                        {
+                            type: 'IMAGE',
+                            name: 'paypal_logo',
+                            source_url: 'https://www.paypalobjects.com/upstream/assets/logos/v2/paypal_wordmark.svg',
+                            alternative_text: 'PayPal'
+                        },
+                        { type: 'TEXT', text: 'Buy now, pay later.' }
+                    ],
+                    action_items: [
+                        {
+                            type: 'LINK',
+                            text: 'Learn more',
+                            click_url: 'https://www.paypal.com/credit-presentment/lander',
+                            embeddable: true
+                        }
+                    ],
+                    disclaimer_items: [{ type: 'TEXT', text: 'Subject to credit approval.' }]
+                }
+            }
+        }
+    ]
 };
 
 const SAMPLE_OPTIONS = {
@@ -57,6 +76,10 @@ function evalBundle(code) {
     const wrapper = new Function('exports', 'module', 'require', code);
     wrapper(exports, mod, require);
     return mod.exports;
+}
+
+function extractPreferredContent(response) {
+    return response?.messages?.[0]?.preferred_message?.content || {};
 }
 
 async function main() {
@@ -129,7 +152,7 @@ async function main() {
     // 5. render — produce HTML
     let html;
     try {
-        html = mod.render(SAMPLE_OPTIONS, SAMPLE_V2_CONTENT, addLog);
+        html = mod.render(SAMPLE_OPTIONS, extractPreferredContent(SAMPLE_V2_RESPONSE), addLog);
     } catch (err) {
         console.error(`✗ render() threw: ${err.message}`);
         process.exit(1);
@@ -144,7 +167,7 @@ async function main() {
     const checks = [
         ['class="pp-message"', 'contains pp-message root'],
         ['class="main', 'contains main span'],
-        ['Pay Later', 'contains main_items content text']
+        ['Buy now, pay later.', 'contains main_items text content']
     ];
     checks.forEach(([needle, label]) => {
         if (!html.includes(needle)) {

--- a/scripts/smoke-test-v2-bundle.js
+++ b/scripts/smoke-test-v2-bundle.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Smoke test for renderV2Message.js stage bundle.
+ * Downloads the bundle from CDN and exercises it like CPNW would.
+ *
+ * Usage:
+ *   node scripts/smoke-test-v2-bundle.js [stageTag]
+ *   node scripts/smoke-test-v2-bundle.js render_v2_msg
+ */
+
+const https = require('https');
+
+const STAGE_TAG = process.argv[2] || 'render_v2_msg';
+const BUNDLE_URL = `https://cdn-${STAGE_TAG}.static.engineering.dev.paypalinc.com/upstream/bizcomponents/stage/renderV2Message.js`;
+
+const SAMPLE_V2_CONTENT = {
+    main_items: [
+        { type: 'text', content: 'Pay Later' },
+        { type: 'text', content: ' with PayPal.' }
+    ],
+    action_items: [{ type: 'text', content: 'Learn more' }],
+    disclaimer_items: [{ type: 'text', content: 'Subject to credit approval.' }],
+    meta: { offerCountry: 'US' }
+};
+
+const SAMPLE_OPTIONS = {
+    style: { layout: 'text', logo: { type: 'primary', position: 'left' }, text: { color: 'black' } },
+    amount: 100,
+    currency: 'USD',
+    locale: 'en_US',
+    buyerCountry: 'US'
+};
+
+function fetch(url) {
+    return new Promise((resolve, reject) => {
+        https
+            .get(url, res => {
+                if (res.statusCode !== 200) {
+                    reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+                    return;
+                }
+                const chunks = [];
+                res.on('data', chunk => chunks.push(chunk));
+                res.on('end', () => resolve(Buffer.concat(chunks).toString()));
+                res.on('error', reject);
+            })
+            .on('error', reject);
+    });
+}
+
+/** Evaluate CommonJS bundle and return its exports — same approach as CPNW's ivm eval */
+function evalBundle(code) {
+    const exports = {};
+    const mod = { exports };
+    // eslint-disable-next-line no-new-func
+    const wrapper = new Function('exports', 'module', 'require', code);
+    wrapper(exports, mod, require);
+    return mod.exports;
+}
+
+async function main() {
+    console.log(`\nFetching bundle from CDN...`);
+    console.log(`  URL: ${BUNDLE_URL}\n`);
+
+    let code;
+    try {
+        code = await fetch(BUNDLE_URL);
+        console.log(`✓ Bundle fetched (${(code.length / 1024).toFixed(1)} KB)`);
+    } catch (err) {
+        console.error(`✗ Failed to fetch bundle: ${err.message}`);
+        process.exit(1);
+    }
+
+    let bundleExports;
+    try {
+        bundleExports = evalBundle(code);
+        console.log(`✓ Bundle evaluated`);
+    } catch (err) {
+        console.error(`✗ Bundle eval failed: ${err.message}`);
+        process.exit(1);
+    }
+
+    // CPNW namespace is exports.renderV2Message
+    const mod = bundleExports.renderV2Message || bundleExports;
+
+    // 1. Check exports
+    const requiredExports = ['render', 'validateStyle', 'getParentStyles', 'version'];
+    const missing = requiredExports.filter(k => typeof mod[k] === 'undefined');
+    if (missing.length) {
+        console.error(`✗ Missing exports: ${missing.join(', ')}`);
+        process.exit(1);
+    }
+    console.log(`✓ All required exports present: ${requiredExports.join(', ')}`);
+    console.log(`  Bundle version: ${mod.version}`);
+
+    // 2. validateStyle
+    const logs = [];
+    const addLog = msg => logs.push(msg);
+    const validatedStyle = mod.validateStyle(addLog, SAMPLE_OPTIONS.style);
+    if (!validatedStyle || validatedStyle.layout !== 'text') {
+        console.error(`✗ validateStyle returned unexpected result: ${JSON.stringify(validatedStyle)}`);
+        process.exit(1);
+    }
+    console.log(`✓ validateStyle works — layout: ${validatedStyle.layout}`);
+
+    // 3. validateStyle with invalid layout (should fall back to 'text')
+    logs.length = 0;
+    const fallback = mod.validateStyle(addLog, { layout: 'invalid_layout' });
+    if (!fallback || fallback.layout !== 'text') {
+        console.error(`✗ validateStyle fallback failed: ${JSON.stringify(fallback)}`);
+        process.exit(1);
+    }
+    if (!logs.some(l => l.includes('invalid_layout') || l.includes('Invalid'))) {
+        console.error(`✗ validateStyle did not log warning for invalid layout`);
+        process.exit(1);
+    }
+    console.log(`✓ validateStyle falls back to 'text' for invalid layout`);
+
+    // 4. validateStyle rejects 'custom' layout
+    logs.length = 0;
+    const customFallback = mod.validateStyle(addLog, { layout: 'custom' });
+    if (!customFallback || customFallback.layout !== 'text') {
+        console.error(`✗ validateStyle did not fall back from 'custom': ${JSON.stringify(customFallback)}`);
+        process.exit(1);
+    }
+    console.log(`✓ validateStyle rejects 'custom' layout and falls back to 'text'`);
+
+    // 5. render — produce HTML
+    let html;
+    try {
+        html = mod.render(SAMPLE_OPTIONS, SAMPLE_V2_CONTENT, addLog);
+    } catch (err) {
+        console.error(`✗ render() threw: ${err.message}`);
+        process.exit(1);
+    }
+    if (typeof html !== 'string' || html.length === 0) {
+        console.error(`✗ render() returned empty or non-string output`);
+        process.exit(1);
+    }
+    console.log(`✓ render() produced HTML (${html.length} chars)`);
+
+    // 6. Check HTML structure
+    const checks = [
+        ['class="pp-message"', 'contains pp-message root'],
+        ['class="main', 'contains main span'],
+        ['Pay Later', 'contains main_items content text']
+    ];
+    checks.forEach(([needle, label]) => {
+        if (!html.includes(needle)) {
+            console.error(`✗ HTML missing: ${label} (looked for "${needle}")`);
+            process.exit(1);
+        }
+        console.log(`✓ HTML ${label}`);
+    });
+
+    // 7. getParentStyles
+    try {
+        const styles = mod.getParentStyles(validatedStyle);
+        if (typeof styles !== 'string') {
+            console.error(`✗ getParentStyles returned non-string: ${typeof styles}`);
+            process.exit(1);
+        }
+        console.log(`✓ getParentStyles returns CSS string (${styles.length} chars)`);
+    } catch (err) {
+        console.error(`✗ getParentStyles threw: ${err.message}`);
+        process.exit(1);
+    }
+
+    console.log('\n✓ All smoke tests passed!\n');
+}
+
+main().catch(err => {
+    console.error('\nUnhandled error:', err);
+    process.exit(1);
+});

--- a/src/server/v2/constants.js
+++ b/src/server/v2/constants.js
@@ -1,0 +1,2 @@
+export const VARIANT = 'B';
+export const PORT = process.env.PORT || 8080;

--- a/src/server/v2/getParentStyles.js
+++ b/src/server/v2/getParentStyles.js
@@ -1,0 +1,149 @@
+const ratioMap = {
+    '1x1': [
+        {
+            ratio: '1x1',
+            width: [120, 300]
+        }
+    ],
+    '1x4': [
+        {
+            ratio: '1x2',
+            width: [160, 160]
+        },
+        {
+            ratio: '1x4',
+            breakpoint: 768
+        }
+    ],
+    '8x1': [
+        {
+            ratio: '6x1',
+            width: [250, 768]
+        },
+        {
+            ratio: '8x1',
+            breakpoint: 768
+        }
+    ],
+    '20x1': [
+        {
+            ratio: '6x1',
+            width: [250, 768]
+        },
+        {
+            ratio: '20x1',
+            width: [350, 1169],
+            breakpoint: 768
+        }
+    ]
+};
+
+function toCSSValue(value) {
+    if (typeof value === 'number') {
+        return `${value}px`;
+    }
+
+    if (typeof value === 'string') {
+        const match = value.match(/^(\d+)x(\d+)$/);
+
+        if (match) {
+            return `${match.slice(1).reduce((denominator, numerator) => +numerator / +denominator) * 100}%`;
+        }
+    }
+
+    return value;
+}
+
+function ratioStringToObject(value) {
+    const [ratio, ...optionalRules] = value.split(/(?=[@[])/);
+
+    if (!ratio.match(/\d+x\d+/)) return {};
+
+    const ratioObject = optionalRules.reduce(
+        (accumulator, rule) => {
+            if (rule.startsWith('@')) {
+                accumulator.breakpoint = rule.slice(1);
+            } else if (rule.startsWith('[')) {
+                accumulator.width = rule.slice(1, -1).split(',');
+            }
+
+            return accumulator;
+        },
+        { ratio }
+    );
+
+    return ratioObject;
+}
+
+export default function getParentStyles(style) {
+    const { ratio: ratioPreset, layout } = style;
+
+    if (!ratioPreset) {
+        return '';
+    }
+
+    let ratioConfig = [];
+    if (layout === 'flex') {
+        ratioConfig = ratioMap[ratioPreset];
+    } else if (Array.isArray(ratioPreset)) {
+        ratioConfig = ratioPreset.map(ratioStringToObject);
+    } else if (typeof ratioPreset === 'string') {
+        ratioConfig = [ratioStringToObject(ratioPreset)];
+    }
+
+    const wrapperClass = `pp-flex--${ratioConfig.slice(-1)[0].ratio}`;
+
+    return ratioConfig.reduce((accumulator, { breakpoint, ratio, width }) => {
+        if (accumulator === '') {
+            return `
+                .${wrapperClass} {
+                    display: block;
+                    width: 100%;
+                    ${
+                        Array.isArray(width)
+                            ? `
+                                min-width: ${toCSSValue(width[0])};
+                                max-width: ${toCSSValue(width[1])};`
+                            : ``
+                    }
+                    box-sizing: border-box;
+                    position: relative;
+                }
+
+                .${wrapperClass}::before {
+                    padding-top: ${toCSSValue(ratio)};
+                    content: '';
+                    display: block;
+                }
+
+                .${wrapperClass} iframe {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                }
+            `;
+        }
+
+        if (!breakpoint) return accumulator;
+
+        return `
+            ${accumulator}
+            @media (min-width: ${toCSSValue(breakpoint)}) {
+                ${
+                    Array.isArray(width)
+                        ? `
+                            .${wrapperClass} {
+                                min-width: ${toCSSValue(width[0])};
+                                max-width: ${toCSSValue(width[1])};
+                            }`
+                        : ``
+                }
+                .${wrapperClass}::before {
+                    padding-top: ${toCSSValue(ratio)};
+                }
+            }
+        `;
+    }, '');
+}

--- a/src/server/v2/getParentStyles.js
+++ b/src/server/v2/getParentStyles.js
@@ -47,7 +47,9 @@ function toCSSValue(value) {
         const match = value.match(/^(\d+)x(\d+)$/);
 
         if (match) {
-            return `${match.slice(1).reduce((denominator, numerator) => +numerator / +denominator) * 100}%`;
+            return `${
+                match.slice(1).reduce((denominator, numerator) => Number(numerator) / Number(denominator)) * 100
+            }%`;
         }
     }
 

--- a/src/server/v2/index.js
+++ b/src/server/v2/index.js
@@ -1,0 +1,5 @@
+export { default as render } from './render';
+export { default as validateStyle } from './validateStyle';
+export { default as getParentStyles } from '../getParentStyles';
+export * from '../constants';
+export const version = __MESSAGES__.__VERSION__;

--- a/src/server/v2/index.js
+++ b/src/server/v2/index.js
@@ -1,5 +1,5 @@
 export { default as render } from './render';
 export { default as validateStyle } from './validateStyle';
-export { default as getParentStyles } from '../getParentStyles';
-export * from '../constants';
+export { default as getParentStyles } from './getParentStyles';
+export * from './constants';
 export const version = __MESSAGES__.__VERSION__;

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -1,0 +1,117 @@
+/** @jsx h */
+/** @jsxFrag Fragment */
+import { h, Fragment } from 'preact';
+
+import { objectMerge, objectFlattenToArray, curry } from '../../utils/server';
+import allStyles from '../message/styles';
+import Styles from '../message/parts/Styles';
+import { getFontRules } from '../message/font';
+
+const DEFAULT_FONT_SIZE = 12;
+
+const applyCascade = curry((style, flattened, type, rules) =>
+    rules.reduce(
+        (accumulator, [key, val]) => {
+            const split = key.split(' && ');
+            if (key === 'default' || split.every(k => flattened.includes(k))) {
+                const calculatedVal =
+                    typeof val === 'function'
+                        ? val({ textSize: (style.text?.size ?? DEFAULT_FONT_SIZE) * 0.983 })
+                        : val;
+                return type === Array ? [...accumulator, calculatedVal] : objectMerge(accumulator, calculatedVal);
+            }
+            return accumulator;
+        },
+        type === Array ? [] : {}
+    )
+);
+
+const renderItem = item => {
+    if (!item) return null;
+    const { type, content, src, dimensions, alt } = item;
+
+    if (type === 'logo' || type === 'image') {
+        const [width, height] = dimensions || [0, 0];
+        return (
+            <div className="message__logo-container" aria-hidden="true">
+                <div className="message__logo message__logo--svg">
+                    <img src={src} alt={alt || ''} role="presentation" />
+                    <canvas height={height} width={width} />
+                </div>
+            </div>
+        );
+    }
+
+    // eslint-disable-next-line react/no-danger
+    return <span dangerouslySetInnerHTML={{ __html: content || '' }} />;
+};
+
+export default ({ options, v2Content }) => {
+    const { style } = options;
+    const { layout } = style;
+
+    const mainItems = v2Content?.main_items ?? [];
+    const actionItems = v2Content?.action_items ?? [];
+    const disclaimerItems = v2Content?.disclaimer_items ?? [];
+    const offerCountry = v2Content?.meta?.offerCountry ?? 'US';
+
+    const localeClass = `locale--${offerCountry}`;
+    const layoutProp = `layout:${layout}`;
+
+    const styleSelectors = objectFlattenToArray(style);
+    const applyCascadeRules = applyCascade(style, styleSelectors);
+
+    const globalStyleRules = applyCascadeRules(Array, allStyles[layoutProp] ?? []);
+    const customFontStyleRules = getFontRules(style);
+
+    const logoItem = mainItems.find(item => item.type === 'logo' || item.type === 'image');
+    const textItems = mainItems.filter(item => item.type !== 'logo' && item.type !== 'image');
+
+    const logoType = logoItem ? style.logo?.type ?? 'primary' : 'none';
+
+    return (
+        <div className="message">
+            <Styles
+                globalStyleRules={globalStyleRules}
+                localeStyleRules={[]}
+                mutationStyleRules={[]}
+                miscStyleRules={[]}
+                customFontStyleRules={customFontStyleRules}
+            />
+            <div className={`message__container ${localeClass}`}>
+                <div className="message__foreground" />
+                <div className="message__content">
+                    {logoType !== 'none' && logoType !== 'inline' && logoItem ? renderItem(logoItem) : null}
+                    <div className="message__messaging">
+                        <div className="message__promo-container">
+                            <div className="message__headline">
+                                {textItems.map((item, idx) => (
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    <Fragment key={idx}>{renderItem(item)}</Fragment>
+                                ))}
+                                {logoType === 'inline' && logoItem ? <> {renderItem(logoItem)}</> : null}
+                            </div>
+                            {actionItems.length > 0 ? (
+                                <div className="message__sub-headline">
+                                    {actionItems.map((item, idx) => (
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        <Fragment key={idx}>{renderItem(item)}</Fragment>
+                                    ))}
+                                </div>
+                            ) : null}
+                        </div>
+                        {disclaimerItems.length > 0 ? (
+                            <p className="message__disclaimer">
+                                {disclaimerItems.map((item, idx) => (
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    <Fragment key={idx}>{renderItem(item)}</Fragment>
+                                ))}
+                            </p>
+                        ) : null}
+                    </div>
+                </div>
+                <div className="message__background" />
+            </div>
+        </div>
+    );
+};

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -10,14 +10,20 @@ import styles from './styles';
 function renderBlock(item) {
     if (!item) return null;
     switch (item.type) {
-        case 'logo':
-        case 'image':
-            return <img src={item.src} alt={item.alt || 'PayPal'} />;
-        case 'link':
-            return <a href={item.href ?? '#'}>{item.content}</a>;
-        case 'text':
+        case 'IMAGE':
+            return <img src={item.source_url} alt={item.alternative_text || 'PayPal'} />;
+        case 'LINK':
+            return (
+                <span
+                    data-iframe-url={item.click_url}
+                    data-embeddable={item.embeddable !== undefined ? String(item.embeddable) : undefined}
+                >
+                    {item.text}
+                </span>
+            );
+        case 'TEXT':
         default:
-            return item.content;
+            return item.text;
     }
 }
 
@@ -37,7 +43,7 @@ export default function V2Message({ options, v2Content }) {
     });
 
     const preparedMainBlocks =
-        disclaimerItems.length > 0 ? [...mainBlocks, { type: 'text', content: ' ' }, ...disclaimerItems] : mainBlocks;
+        disclaimerItems.length > 0 ? [...mainBlocks, { type: 'TEXT', text: ' ' }, ...disclaimerItems] : mainBlocks;
 
     const logoClasses = mapClasses({ logo: true, [textColor]: true, [logoPosition]: true, [logoType]: true });
     const mainClasses = mapClasses({ main: true, [logoPosition]: true, [textColor]: true });
@@ -51,7 +57,7 @@ export default function V2Message({ options, v2Content }) {
             {/* eslint-disable-next-line react/no-danger */}
             <style dangerouslySetInnerHTML={{ __html: styles }} />
             {hasInitialLogo && logoBlock && logoType !== 'none' ? (
-                <span role="img" aria-label={logoBlock.alt || 'PayPal'} className={logoClasses}>
+                <span role="img" aria-label={logoBlock.alternative_text || 'PayPal'} className={logoClasses}>
                     {renderBlock(logoBlock)}
                 </span>
             ) : null}
@@ -70,7 +76,7 @@ export default function V2Message({ options, v2Content }) {
                 </span>
             ) : null}
             {hasRightLogo && logoBlock && logoType !== 'none' ? (
-                <span role="img" aria-label={logoBlock.alt || 'PayPal'} className={logoClasses}>
+                <span role="img" aria-label={logoBlock.alternative_text || 'PayPal'} className={logoClasses}>
                     {renderBlock(logoBlock)}
                 </span>
             ) : null}

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -54,8 +54,17 @@ export default function V2Message({ options, v2Content }) {
 
     return (
         <div className="pp-message">
-            {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: styles({ fontSize: style.text?.size }) }} />
+            {/* eslint-disable react/no-danger */}
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: styles({
+                        fontFamily: style.text?.fontFamily,
+                        fontSize: style.text?.size,
+                        textAlign: style.text?.align
+                    })
+                }}
+            />
+            {/* eslint-enable react/no-danger */}
             {hasInitialLogo && logoBlock && logoType !== 'none' ? (
                 <span role="img" aria-label={logoBlock.alternative_text || 'PayPal'} className={logoClasses}>
                     {renderBlock(logoBlock)}

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -31,7 +31,7 @@ export default function V2Message({ options, v2Content }) {
     const { style } = options;
     const logoPosition = style.logo?.type === 'inline' ? 'inline' : style.logo?.position ?? 'left';
     const logoType = style.logo?.type ?? 'primary';
-    const textColor = style.text?.color ?? 'black';
+    const textColor = style.layout === 'flex' ? style.color ?? 'black' : style.text?.color ?? 'black';
 
     const mainItems = v2Content?.main_items ?? [];
     const actionItems = v2Content?.action_items ?? [];
@@ -55,7 +55,7 @@ export default function V2Message({ options, v2Content }) {
     return (
         <div className="pp-message">
             {/* eslint-disable-next-line react/no-danger */}
-            <style dangerouslySetInnerHTML={{ __html: styles }} />
+            <style dangerouslySetInnerHTML={{ __html: styles({ fontSize: style.text?.size }) }} />
             {hasInitialLogo && logoBlock && logoType !== 'none' ? (
                 <span role="img" aria-label={logoBlock.alternative_text || 'PayPal'} className={logoClasses}>
                     {renderBlock(logoBlock)}

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -14,8 +14,7 @@ function renderBlock(item) {
         case 'image':
             return <img src={item.src} alt={item.alt || 'PayPal'} />;
         case 'link':
-            // eslint-disable-next-line jsx-a11y/anchor-is-valid
-            return <a href="#">{item.content}</a>;
+            return <a href={item.href ?? '#'}>{item.content}</a>;
         case 'text':
         default:
             return item.content;

--- a/src/server/v2/message.jsx
+++ b/src/server/v2/message.jsx
@@ -2,116 +2,79 @@
 /** @jsxFrag Fragment */
 import { h, Fragment } from 'preact';
 
-import { objectMerge, objectFlattenToArray, curry } from '../../utils/server';
-import allStyles from '../message/styles';
-import Styles from '../message/parts/Styles';
-import { getFontRules } from '../message/font';
+import { buildContentLabel } from './utils/buildContentLabel';
+import { buildLogoConfiguration } from './utils/buildLogoConfiguration';
+import { mapClasses } from './utils/mapClasses';
+import styles from './styles';
 
-const DEFAULT_FONT_SIZE = 12;
-
-const applyCascade = curry((style, flattened, type, rules) =>
-    rules.reduce(
-        (accumulator, [key, val]) => {
-            const split = key.split(' && ');
-            if (key === 'default' || split.every(k => flattened.includes(k))) {
-                const calculatedVal =
-                    typeof val === 'function'
-                        ? val({ textSize: (style.text?.size ?? DEFAULT_FONT_SIZE) * 0.983 })
-                        : val;
-                return type === Array ? [...accumulator, calculatedVal] : objectMerge(accumulator, calculatedVal);
-            }
-            return accumulator;
-        },
-        type === Array ? [] : {}
-    )
-);
-
-const renderItem = item => {
+function renderBlock(item) {
     if (!item) return null;
-    const { type, content, src, dimensions, alt } = item;
-
-    if (type === 'logo' || type === 'image') {
-        const [width, height] = dimensions || [0, 0];
-        return (
-            <div className="message__logo-container" aria-hidden="true">
-                <div className="message__logo message__logo--svg">
-                    <img src={src} alt={alt || ''} role="presentation" />
-                    <canvas height={height} width={width} />
-                </div>
-            </div>
-        );
+    switch (item.type) {
+        case 'logo':
+        case 'image':
+            return <img src={item.src} alt={item.alt || 'PayPal'} />;
+        case 'link':
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid
+            return <a href="#">{item.content}</a>;
+        case 'text':
+        default:
+            return item.content;
     }
+}
 
-    // eslint-disable-next-line react/no-danger
-    return <span dangerouslySetInnerHTML={{ __html: content || '' }} />;
-};
-
-export default ({ options, v2Content }) => {
+export default function V2Message({ options, v2Content }) {
     const { style } = options;
-    const { layout } = style;
+    const logoPosition = style.logo?.type === 'inline' ? 'inline' : style.logo?.position ?? 'left';
+    const logoType = style.logo?.type ?? 'primary';
+    const textColor = style.text?.color ?? 'black';
 
     const mainItems = v2Content?.main_items ?? [];
     const actionItems = v2Content?.action_items ?? [];
     const disclaimerItems = v2Content?.disclaimer_items ?? [];
-    const offerCountry = v2Content?.meta?.offerCountry ?? 'US';
 
-    const localeClass = `locale--${offerCountry}`;
-    const layoutProp = `layout:${layout}`;
+    const { logoBlock, hasInitialLogo, hasRightLogo, mainBlocks } = buildLogoConfiguration({
+        logoPosition,
+        mainItems
+    });
 
-    const styleSelectors = objectFlattenToArray(style);
-    const applyCascadeRules = applyCascade(style, styleSelectors);
+    const preparedMainBlocks =
+        disclaimerItems.length > 0 ? [...mainBlocks, { type: 'text', content: ' ' }, ...disclaimerItems] : mainBlocks;
 
-    const globalStyleRules = applyCascadeRules(Array, allStyles[layoutProp] ?? []);
-    const customFontStyleRules = getFontRules(style);
+    const logoClasses = mapClasses({ logo: true, [textColor]: true, [logoPosition]: true, [logoType]: true });
+    const mainClasses = mapClasses({ main: true, [logoPosition]: true, [textColor]: true });
+    const actionClasses = mapClasses({ action: true, [textColor]: true });
 
-    const logoItem = mainItems.find(item => item.type === 'logo' || item.type === 'image');
-    const textItems = mainItems.filter(item => item.type !== 'logo' && item.type !== 'image');
-
-    const logoType = logoItem ? style.logo?.type ?? 'primary' : 'none';
+    const mainLabel = buildContentLabel(preparedMainBlocks);
+    const actionLabel = buildContentLabel(actionItems);
 
     return (
-        <div className="message">
-            <Styles
-                globalStyleRules={globalStyleRules}
-                localeStyleRules={[]}
-                mutationStyleRules={[]}
-                miscStyleRules={[]}
-                customFontStyleRules={customFontStyleRules}
-            />
-            <div className={`message__container ${localeClass}`}>
-                <div className="message__foreground" />
-                <div className="message__content">
-                    {logoType !== 'none' && logoType !== 'inline' && logoItem ? renderItem(logoItem) : null}
-                    <div className="message__messaging">
-                        <div className="message__promo-container">
-                            <div className="message__headline">
-                                {textItems.map((item, idx) => (
-                                    // eslint-disable-next-line react/no-array-index-key
-                                    <Fragment key={idx}>{renderItem(item)}</Fragment>
-                                ))}
-                                {logoType === 'inline' && logoItem ? <> {renderItem(logoItem)}</> : null}
-                            </div>
-                            {actionItems.length > 0 ? (
-                                <div className="message__sub-headline">
-                                    {actionItems.map((item, idx) => (
-                                        // eslint-disable-next-line react/no-array-index-key
-                                        <Fragment key={idx}>{renderItem(item)}</Fragment>
-                                    ))}
-                                </div>
-                            ) : null}
-                        </div>
-                        {disclaimerItems.length > 0 ? (
-                            <p className="message__disclaimer">
-                                {disclaimerItems.map((item, idx) => (
-                                    // eslint-disable-next-line react/no-array-index-key
-                                    <Fragment key={idx}>{renderItem(item)}</Fragment>
-                                ))}
-                            </p>
-                        ) : null}
-                    </div>
-                </div>
-                <div className="message__background" />
-            </div>
+        <div className="pp-message">
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: styles }} />
+            {hasInitialLogo && logoBlock && logoType !== 'none' ? (
+                <span role="img" aria-label={logoBlock.alt || 'PayPal'} className={logoClasses}>
+                    {renderBlock(logoBlock)}
+                </span>
+            ) : null}
+            <span aria-label={mainLabel} className={mainClasses}>
+                {preparedMainBlocks.map((item, idx) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <Fragment key={idx}>{renderBlock(item)}</Fragment>
+                ))}
+            </span>
+            {actionItems.length > 0 ? (
+                <span aria-label={actionLabel} className={actionClasses}>
+                    {actionItems.map((item, idx) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <Fragment key={idx}>{renderBlock(item)}</Fragment>
+                    ))}
+                </span>
+            ) : null}
+            {hasRightLogo && logoBlock && logoType !== 'none' ? (
+                <span role="img" aria-label={logoBlock.alt || 'PayPal'} className={logoClasses}>
+                    {renderBlock(logoBlock)}
+                </span>
+            ) : null}
         </div>
     );
-};
+}

--- a/src/server/v2/render.jsx
+++ b/src/server/v2/render.jsx
@@ -4,6 +4,6 @@ import render from 'preact-render-to-string';
 
 import V2Message from './message';
 
-export default (options, v2Content, addLog) => {
-    return render(<V2Message addLog={addLog} options={options} v2Content={v2Content} />);
+export default (options, v2Content) => {
+    return render(<V2Message options={options} v2Content={v2Content} />);
 };

--- a/src/server/v2/render.jsx
+++ b/src/server/v2/render.jsx
@@ -1,0 +1,9 @@
+/** @jsx h */
+import { h } from 'preact';
+import render from 'preact-render-to-string';
+
+import V2Message from './message';
+
+export default (options, v2Content, addLog) => {
+    return render(<V2Message addLog={addLog} options={options} v2Content={v2Content} />);
+};

--- a/src/server/v2/styles.js
+++ b/src/server/v2/styles.js
@@ -1,9 +1,13 @@
-export default ({ fontSize = 12 } = {}) => `
+export default ({
+    fontFamily = '"PayPal Pro", Helvetica, Arial, "Liberation Sans", sans-serif',
+    fontSize = 12,
+    textAlign = 'left'
+} = {}) => `
 .pp-message {
-    font-family: "PayPal Pro", Helvetica, Arial, "Liberation Sans", sans-serif;
+    font-family: ${fontFamily};
     font-weight: 450;
     font-size: ${fontSize}px;
-    text-align: left;
+    text-align: ${textAlign};
 }
 
 .pp-message .main.black { color: #000; }

--- a/src/server/v2/styles.js
+++ b/src/server/v2/styles.js
@@ -1,8 +1,8 @@
-export default `
+export default ({ fontSize = 12 } = {}) => `
 .pp-message {
     font-family: "PayPal Pro", Helvetica, Arial, "Liberation Sans", sans-serif;
     font-weight: 450;
-    font-size: 14px;
+    font-size: ${fontSize}px;
     text-align: left;
 }
 
@@ -11,13 +11,13 @@ export default `
 .pp-message .main.grayscale { color: #000; }
 .pp-message .main.white { color: #fff; }
 
-.pp-message .action a {
+.pp-message .action [data-iframe-url] {
     color: #0070ba;
     white-space: nowrap;
 }
-.pp-message .action.monochrome > a { color: #000; }
-.pp-message .action.grayscale > a { color: #000; }
-.pp-message .action.white > a { color: #fff; }
+.pp-message .action.monochrome > [data-iframe-url] { color: #000; }
+.pp-message .action.grayscale > [data-iframe-url] { color: #000; }
+.pp-message .action.white > [data-iframe-url] { color: #fff; }
 
 .pp-message .logo { display: inline-block; }
 .pp-message .logo.top { display: block; }

--- a/src/server/v2/styles.js
+++ b/src/server/v2/styles.js
@@ -1,0 +1,32 @@
+export default `
+.pp-message {
+    font-family: "PayPal Pro", Helvetica, Arial, "Liberation Sans", sans-serif;
+    font-weight: 450;
+    font-size: 14px;
+    text-align: left;
+}
+
+.pp-message .main.black { color: #000; }
+.pp-message .main.monochrome { color: #000; }
+.pp-message .main.grayscale { color: #000; }
+.pp-message .main.white { color: #fff; }
+
+.pp-message .action a {
+    color: #0070ba;
+    white-space: nowrap;
+}
+.pp-message .action.monochrome > a { color: #000; }
+.pp-message .action.grayscale > a { color: #000; }
+.pp-message .action.white > a { color: #fff; }
+
+.pp-message .logo { display: inline-block; }
+.pp-message .logo.top { display: block; }
+
+.pp-message img {
+    max-height: 1.25em;
+    height: 1.25em;
+    width: auto;
+    vertical-align: middle;
+    margin-right: 0.3125em;
+}
+`;

--- a/src/server/v2/types.js
+++ b/src/server/v2/types.js
@@ -1,0 +1,27 @@
+export const Types = {
+    ANY: 'ANY',
+    STRING: 'STRING',
+    BOOLEAN: 'BOOLEAN',
+    NUMBER: 'NUMBER',
+    FUNCTION: 'FUNCTION',
+    OBJECT: 'OBJECT'
+};
+
+export function validateType(expectedType, val) {
+    switch (expectedType) {
+        case Types.STRING:
+            return typeof val === 'string';
+        case Types.BOOLEAN:
+            return typeof val === 'boolean';
+        case Types.NUMBER:
+            return typeof val === 'number' && !Number.isNaN(val);
+        case Types.FUNCTION:
+            return typeof val === 'function';
+        case Types.OBJECT:
+            return typeof val === 'object' && val !== null;
+        case Types.ANY:
+            return true;
+        default:
+            return false;
+    }
+}

--- a/src/server/v2/utils/buildContentLabel.js
+++ b/src/server/v2/utils/buildContentLabel.js
@@ -1,0 +1,6 @@
+export function buildContentLabel(items) {
+    return items
+        .map(item => (item.alt || item.content)?.trim())
+        .filter(Boolean)
+        .join(' ');
+}

--- a/src/server/v2/utils/buildContentLabel.js
+++ b/src/server/v2/utils/buildContentLabel.js
@@ -1,6 +1,6 @@
 export function buildContentLabel(items) {
     return items
-        .map(item => (item.alt || item.content)?.trim())
+        .map(item => (item.alternative_text || item.text)?.trim())
         .filter(Boolean)
         .join(' ');
 }

--- a/src/server/v2/utils/buildLogoConfiguration.js
+++ b/src/server/v2/utils/buildLogoConfiguration.js
@@ -3,8 +3,8 @@ export function buildLogoConfiguration({ logoPosition, mainItems }) {
         return { hasInitialLogo: false, hasRightLogo: false, logoBlock: undefined, mainBlocks: mainItems };
     }
 
-    const logoBlock = mainItems.find(item => item.type === 'logo' || item.type === 'image');
-    const mainBlocks = mainItems.filter(item => item.type !== 'logo' && item.type !== 'image');
+    const logoBlock = mainItems.find(item => item.type === 'IMAGE');
+    const mainBlocks = mainItems.filter(item => item.type !== 'IMAGE');
 
     return {
         hasInitialLogo: !!logoBlock && (logoPosition === 'left' || logoPosition === 'top'),

--- a/src/server/v2/utils/buildLogoConfiguration.js
+++ b/src/server/v2/utils/buildLogoConfiguration.js
@@ -1,0 +1,15 @@
+export function buildLogoConfiguration({ logoPosition, mainItems }) {
+    if (logoPosition === 'inline') {
+        return { hasInitialLogo: false, hasRightLogo: false, logoBlock: undefined, mainBlocks: mainItems };
+    }
+
+    const logoBlock = mainItems.find(item => item.type === 'logo' || item.type === 'image');
+    const mainBlocks = mainItems.filter(item => item.type !== 'logo' && item.type !== 'image');
+
+    return {
+        hasInitialLogo: !!logoBlock && (logoPosition === 'left' || logoPosition === 'top'),
+        hasRightLogo: !!logoBlock && logoPosition === 'right',
+        logoBlock,
+        mainBlocks
+    };
+}

--- a/src/server/v2/utils/mapClasses.js
+++ b/src/server/v2/utils/mapClasses.js
@@ -1,0 +1,6 @@
+export function mapClasses(classMap) {
+    return Object.entries(classMap)
+        .filter(([name, on]) => on && !name.includes(' ') && name.trim().length > 0)
+        .map(([name]) => name.toLowerCase().replace(/_/g, '-'))
+        .join(' ');
+}

--- a/src/server/v2/validOptions.js
+++ b/src/server/v2/validOptions.js
@@ -1,0 +1,28 @@
+import { Types } from '../types';
+
+export default {
+    text: {
+        logo: {
+            type: [Types.STRING, ['primary', 'alternative', 'inline', 'none']],
+            position: [Types.STRING, ['left', 'right', 'top']]
+        },
+        text: {
+            color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
+            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
+            align: [Types.STRING, ['left', 'right', 'center']],
+            fontFamily: [Types.ANY],
+            fontSource: [Types.ANY]
+        }
+    },
+    flex: {
+        color: [
+            Types.STRING,
+            ['blue', 'black', 'white', 'white-no-border', 'gray|grey', 'monochrome', 'grayscale|greyscale']
+        ],
+        ratio: [Types.STRING, ['1x1', '1x4', '8x1', '20x1']],
+        text: {
+            fontFamily: [Types.ANY],
+            fontSource: [Types.ANY]
+        }
+    }
+};

--- a/src/server/v2/validOptions.js
+++ b/src/server/v2/validOptions.js
@@ -1,4 +1,4 @@
-import { Types } from '../types';
+import { Types } from './types';
 
 export default {
     text: {

--- a/src/server/v2/validateStyle.js
+++ b/src/server/v2/validateStyle.js
@@ -3,6 +3,9 @@ import { validateType, Types } from './types';
 
 const logInvalid = (addLog, location, message) => addLog(`Invalid option value (${location}). ${message}`);
 
+const logInvalidType = (addLog, location, expectedType, val) =>
+    logInvalid(addLog, location, `Expected type "${expectedType.toLowerCase()}" but instead received "${typeof val}".`);
+
 const logInvalidOption = (addLog, location, options, val) =>
     logInvalid(
         addLog,
@@ -57,7 +60,7 @@ function getValidVal(addLog, typeArr, val, location) {
         return numberVal;
     }
 
-    logInvalid(addLog, location, `Expected type "${type.toLowerCase()}" but instead received "${typeof val}".`);
+    logInvalidType(addLog, location, type, val);
     return validVals[0];
 }
 

--- a/src/server/v2/validateStyle.js
+++ b/src/server/v2/validateStyle.js
@@ -1,5 +1,92 @@
 import validOptions from './validOptions';
-import { logInvalidOption, buildValidStyle } from '../validateStyle';
+import { validateType, Types } from './types';
+
+const logInvalid = (addLog, location, message) => addLog(`Invalid option value (${location}). ${message}`);
+
+const logInvalidOption = (addLog, location, options, val) =>
+    logInvalid(
+        addLog,
+        location,
+        // Filter out potentially malicious inputs from warnings.
+        `Expected one of ["${options.join('", "').replace(/\|[\w|]+/g, '')}"] but received "${
+            /^[a-z0-9]+$/i.test(val) ? val : 'REDACTED'
+        }".`
+    );
+
+function getValidVal(addLog, typeArr, val, location) {
+    const [type, validVals = []] = typeArr;
+
+    if (val === undefined) {
+        return validVals[0];
+    }
+
+    if (type !== Types.NUMBER && validateType(type, val)) {
+        if (type === Types.STRING && validVals.length > 0) {
+            const validVal = validVals.find(v => {
+                if (typeof v !== 'string') {
+                    return false;
+                }
+                return v.split('|').some(x => x === val);
+            });
+
+            if (validVal === undefined) {
+                logInvalidOption(addLog, location, validVals, val);
+                if (typeof validVals[0] === 'undefined') {
+                    return validVals[0];
+                }
+                return validVals[0].split('|')[0];
+            }
+
+            return validVal.split('|')[0];
+        }
+        return val;
+    }
+
+    const numberVal = Number(val);
+    if (type === Types.NUMBER && validateType(type, numberVal)) {
+        if (validVals.length > 0) {
+            const validVal = validVals.find(v => v === numberVal);
+            if (validVal === undefined) {
+                logInvalidOption(addLog, location, validVals, numberVal);
+                return validVals[0];
+            }
+
+            return validVal;
+        }
+
+        return numberVal;
+    }
+
+    logInvalid(addLog, location, `Expected type "${type.toLowerCase()}" but instead received "${typeof val}".`);
+    return validVals[0];
+}
+
+function populateDefaults(addLog, defaults, options, prefix = 'style.') {
+    return Object.entries(defaults).reduce((accumulator, [key, val]) => {
+        if (Array.isArray(val)) {
+            const validVal = getValidVal(addLog, val, options[key], `${prefix}${key}`);
+
+            return validVal === undefined
+                ? accumulator
+                : {
+                      ...accumulator,
+                      [key]: validVal
+                  };
+        }
+
+        return {
+            ...accumulator,
+            [key]: populateDefaults(addLog, defaults[key], options[key] ?? {}, `${prefix}${key}.`)
+        };
+    }, {});
+}
+
+function buildValidStyle(addLog, layoutOptions, options) {
+    return {
+        layout: options.layout,
+        ...populateDefaults(addLog, layoutOptions[options.layout], options)
+    };
+}
 
 export default (addLog, style) => {
     if (style.layout === 'custom') {

--- a/src/server/v2/validateStyle.js
+++ b/src/server/v2/validateStyle.js
@@ -1,0 +1,18 @@
+import validOptions from './validOptions';
+import { logInvalidOption, buildValidStyle } from '../validateStyle';
+
+export default (addLog, style) => {
+    if (style.layout === 'custom') {
+        addLog(
+            'Invalid option value (style.layout). The "custom" layout is not supported by renderV2Message; falling back to "text".'
+        );
+        return buildValidStyle(addLog, validOptions, { layout: 'text' });
+    }
+
+    if (validOptions[style.layout]) {
+        return buildValidStyle(addLog, validOptions, style);
+    }
+
+    logInvalidOption(addLog, 'style.layout', Object.keys(validOptions), style.layout);
+    return buildValidStyle(addLog, validOptions, { layout: 'text' });
+};

--- a/src/server/v2/validateStyle.js
+++ b/src/server/v2/validateStyle.js
@@ -91,18 +91,21 @@ function buildValidStyle(addLog, layoutOptions, options) {
     };
 }
 
-export default (addLog, style) => {
-    if (style.layout === 'custom') {
+export default (addLog, style = {}) => {
+    const safeStyle = style ?? {};
+    const layout = safeStyle.layout ?? 'text';
+
+    if (layout === 'custom') {
         addLog(
             'Invalid option value (style.layout). The "custom" layout is not supported by renderV2Message; falling back to "text".'
         );
         return buildValidStyle(addLog, validOptions, { layout: 'text' });
     }
 
-    if (validOptions[style.layout]) {
-        return buildValidStyle(addLog, validOptions, style);
+    if (validOptions[layout]) {
+        return buildValidStyle(addLog, validOptions, { ...safeStyle, layout });
     }
 
-    logInvalidOption(addLog, 'style.layout', Object.keys(validOptions), style.layout);
+    logInvalidOption(addLog, 'style.layout', Object.keys(validOptions), layout);
     return buildValidStyle(addLog, validOptions, { layout: 'text' });
 };

--- a/src/server/validateStyle.js
+++ b/src/server/validateStyle.js
@@ -5,7 +5,7 @@ import { validateType, Types } from './types';
 const logInvalid = (addLog, location, message) => addLog(`Invalid option value (${location}). ${message}`);
 const logInvalidType = (addLog, location, expectedType, val) =>
     logInvalid(addLog, location, `Expected type "${expectedType.toLowerCase()}" but instead received "${typeof val}".`);
-export const logInvalidOption = (addLog, location, options, val) =>
+const logInvalidOption = (addLog, location, options, val) =>
     logInvalid(
         addLog,
         location,
@@ -15,7 +15,7 @@ export const logInvalidOption = (addLog, location, options, val) =>
         }".`
     );
 
-export function getValidVal(addLog, typeArr, val, location) {
+function getValidVal(addLog, typeArr, val, location) {
     const [type, validVals = []] = typeArr;
 
     if (val === undefined) {
@@ -72,7 +72,7 @@ export function getValidVal(addLog, typeArr, val, location) {
  * @param {String} prefix Keep track of property location. Used for logging.
  * @returns {Object} Object with user style options or default values if missing
  */
-export function populateDefaults(addLog, defaults, options, prefix = 'style.') {
+function populateDefaults(addLog, defaults, options, prefix = 'style.') {
     return Object.entries(defaults).reduce((accumulator, [key, val]) => {
         if (Array.isArray(val)) {
             const validVal = getValidVal(addLog, val, options[key], `${prefix}${key}`);
@@ -98,7 +98,7 @@ export function populateDefaults(addLog, defaults, options, prefix = 'style.') {
  * @param {Object} options User style options
  * @returns {Object} Object containing only valid style options
  */
-export function buildValidStyle(addLog, layoutOptions, options) {
+function buildValidStyle(addLog, layoutOptions, options) {
     return {
         layout: options.layout,
         ...populateDefaults(addLog, layoutOptions[options.layout], options)

--- a/src/server/validateStyle.js
+++ b/src/server/validateStyle.js
@@ -98,11 +98,13 @@ function populateDefaults(addLog, defaults, options, prefix = 'style.') {
  * @param {Object} options User style options
  * @returns {Object} Object containing only valid style options
  */
-function buildValidStyle(addLog, layoutOptions, options) {
-    return {
+function getValidStyleOptions(addLog, localeStyleOptions, options) {
+    const defaultValues = {
         layout: options.layout,
-        ...populateDefaults(addLog, layoutOptions[options.layout], options)
+        ...populateDefaults(addLog, localeStyleOptions[options.layout], options)
     };
+
+    return defaultValues;
 }
 
 /**
@@ -115,11 +117,13 @@ export default (addLog, style, locale, offerType, contextualComponents) => {
     const validStyleOptions = getValidOptions(locale, offerType, contextualComponents);
 
     if (validStyleOptions[style.layout]) {
-        return buildValidStyle(addLog, validStyleOptions, style);
+        return getValidStyleOptions(addLog, validStyleOptions, style);
     }
 
     logInvalidOption(addLog, 'style.layout', Object.keys(validStyleOptions), style.layout);
 
     // Get the default settings for a text banner
-    return buildValidStyle(addLog, validStyleOptions, { layout: 'text' });
+    return getValidStyleOptions(addLog, validStyleOptions, {
+        layout: 'text'
+    });
 };

--- a/src/server/validateStyle.js
+++ b/src/server/validateStyle.js
@@ -5,7 +5,7 @@ import { validateType, Types } from './types';
 const logInvalid = (addLog, location, message) => addLog(`Invalid option value (${location}). ${message}`);
 const logInvalidType = (addLog, location, expectedType, val) =>
     logInvalid(addLog, location, `Expected type "${expectedType.toLowerCase()}" but instead received "${typeof val}".`);
-const logInvalidOption = (addLog, location, options, val) =>
+export const logInvalidOption = (addLog, location, options, val) =>
     logInvalid(
         addLog,
         location,
@@ -15,7 +15,7 @@ const logInvalidOption = (addLog, location, options, val) =>
         }".`
     );
 
-function getValidVal(addLog, typeArr, val, location) {
+export function getValidVal(addLog, typeArr, val, location) {
     const [type, validVals = []] = typeArr;
 
     if (val === undefined) {
@@ -72,7 +72,7 @@ function getValidVal(addLog, typeArr, val, location) {
  * @param {String} prefix Keep track of property location. Used for logging.
  * @returns {Object} Object with user style options or default values if missing
  */
-function populateDefaults(addLog, defaults, options, prefix = 'style.') {
+export function populateDefaults(addLog, defaults, options, prefix = 'style.') {
     return Object.entries(defaults).reduce((accumulator, [key, val]) => {
         if (Array.isArray(val)) {
             const validVal = getValidVal(addLog, val, options[key], `${prefix}${key}`);
@@ -98,13 +98,11 @@ function populateDefaults(addLog, defaults, options, prefix = 'style.') {
  * @param {Object} options User style options
  * @returns {Object} Object containing only valid style options
  */
-function getValidStyleOptions(addLog, localeStyleOptions, options) {
-    const defaultValues = {
+export function buildValidStyle(addLog, layoutOptions, options) {
+    return {
         layout: options.layout,
-        ...populateDefaults(addLog, localeStyleOptions[options.layout], options)
+        ...populateDefaults(addLog, layoutOptions[options.layout], options)
     };
-
-    return defaultValues;
 }
 
 /**
@@ -117,13 +115,11 @@ export default (addLog, style, locale, offerType, contextualComponents) => {
     const validStyleOptions = getValidOptions(locale, offerType, contextualComponents);
 
     if (validStyleOptions[style.layout]) {
-        return getValidStyleOptions(addLog, validStyleOptions, style);
+        return buildValidStyle(addLog, validStyleOptions, style);
     }
 
     logInvalidOption(addLog, 'style.layout', Object.keys(validStyleOptions), style.layout);
 
     // Get the default settings for a text banner
-    return getValidStyleOptions(addLog, validStyleOptions, {
-        layout: 'text'
-    });
+    return buildValidStyle(addLog, validStyleOptions, { layout: 'text' });
 };

--- a/tests/unit/spec/server/v2/index.test.js
+++ b/tests/unit/spec/server/v2/index.test.js
@@ -1,0 +1,19 @@
+import * as v2Module from 'server/v2/index';
+
+describe('renderV2Message module contract', () => {
+    test('exports render function', () => {
+        expect(typeof v2Module.render).toBe('function');
+    });
+
+    test('exports validateStyle function', () => {
+        expect(typeof v2Module.validateStyle).toBe('function');
+    });
+
+    test('exports getParentStyles function', () => {
+        expect(typeof v2Module.getParentStyles).toBe('function');
+    });
+
+    test('exports version string', () => {
+        expect(typeof v2Module.version).toBe('string');
+    });
+});

--- a/tests/unit/spec/server/v2/render.test.js
+++ b/tests/unit/spec/server/v2/render.test.js
@@ -11,10 +11,9 @@ const baseOptions = {
 };
 
 const baseV2Content = {
-    meta: { offerCountry: 'US' },
-    main_items: [{ type: 'text', content: 'Pay Later' }],
-    action_items: [{ type: 'text', content: 'Learn more' }],
-    disclaimer_items: [{ type: 'text', content: 'Subject to approval.' }]
+    main_items: [{ type: 'TEXT', text: 'Pay Later' }],
+    action_items: [{ type: 'LINK', text: 'Learn more', click_url: 'https://example.com/lander', embeddable: true }],
+    disclaimer_items: [{ type: 'TEXT', text: 'Subject to approval.' }]
 };
 
 describe('v2 render', () => {
@@ -63,12 +62,17 @@ describe('v2 render', () => {
         expect(result).not.toMatch(/class="action[^"]*"/);
     });
 
-    test('renders logo item as img in .logo span', () => {
+    test('renders IMAGE item as img in .logo span', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
-                { type: 'text', content: 'Pay Later' }
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                },
+                { type: 'TEXT', text: 'Pay Later' }
             ]
         };
         const result = render(baseOptions, content, mockLog);
@@ -81,8 +85,13 @@ describe('v2 render', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
-                { type: 'text', content: 'Pay Later' }
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                },
+                { type: 'TEXT', text: 'Pay Later' }
             ]
         };
         const result = render(baseOptions, content, mockLog);
@@ -94,8 +103,13 @@ describe('v2 render', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'text', content: 'Pay Later' },
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' }
+                { type: 'TEXT', text: 'Pay Later' },
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                }
             ]
         };
         const result = render(options, content, mockLog);
@@ -107,8 +121,13 @@ describe('v2 render', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
-                { type: 'text', content: 'Pay Later' }
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                },
+                { type: 'TEXT', text: 'Pay Later' }
             ]
         };
         const result = render(options, content, mockLog);
@@ -120,8 +139,13 @@ describe('v2 render', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'text', content: 'Pay Later' },
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' }
+                { type: 'TEXT', text: 'Pay Later' },
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                }
             ]
         };
         const result = render(options, content, mockLog);
@@ -129,45 +153,46 @@ describe('v2 render', () => {
         expect(result).not.toMatch(/role="img"/);
     });
 
-    test('logo type none suppresses logo span even when logo item is present', () => {
+    test('logo type none suppresses logo span even when IMAGE item is present', () => {
         const options = { style: { ...baseOptions.style, logo: { type: 'none', position: 'left' } } };
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
-                { type: 'text', content: 'Pay Later' }
+                {
+                    type: 'IMAGE',
+                    source_url: 'https://example.com/logo.svg',
+                    alternative_text: 'PayPal',
+                    name: 'paypal_logo'
+                },
+                { type: 'TEXT', text: 'Pay Later' }
             ]
         };
         const result = render(options, content, mockLog);
         expect(result).not.toMatch(/role="img"/);
     });
 
-    test('renders link item as an anchor tag', () => {
+    test('renders LINK item as a span with data attributes (not an anchor)', () => {
         const content = {
             ...baseV2Content,
-            main_items: [{ type: 'link', content: 'Terms apply' }]
+            main_items: [
+                { type: 'LINK', text: 'Terms apply', click_url: 'https://example.com/terms', embeddable: true }
+            ]
         };
         const result = render(baseOptions, content, mockLog);
-        expect(result).toContain('<a');
         expect(result).toContain('Terms apply');
+        expect(result).toContain('data-iframe-url="https://example.com/terms"');
+        expect(result).toContain('data-embeddable="true"');
+        expect(result).not.toContain('<a');
     });
 
-    test('uses item.href on link items when present', () => {
+    test('omits data-embeddable when embeddable is not present on LINK item', () => {
         const content = {
             ...baseV2Content,
-            main_items: [{ type: 'link', content: 'Terms apply', href: 'https://example.com/terms' }]
+            main_items: [{ type: 'LINK', text: 'Terms apply', click_url: 'https://example.com/terms' }],
+            action_items: []
         };
         const result = render(baseOptions, content, mockLog);
-        expect(result).toContain('href="https://example.com/terms"');
-    });
-
-    test('falls back to # when link item has no href', () => {
-        const content = {
-            ...baseV2Content,
-            main_items: [{ type: 'link', content: 'Terms apply' }]
-        };
-        const result = render(baseOptions, content, mockLog);
-        expect(result).toContain('href="#"');
+        expect(result).not.toContain('data-embeddable');
     });
 
     test('applies text color class to main span', () => {

--- a/tests/unit/spec/server/v2/render.test.js
+++ b/tests/unit/spec/server/v2/render.test.js
@@ -1,0 +1,126 @@
+import render from 'server/v2/render';
+
+jest.mock('server/message/styles', () => ({
+    __esModule: true,
+    default: {
+        'layout:text': [['default', '.message { display: block; }']],
+        'layout:flex': [['default', '.message { display: flex; }']]
+    }
+}));
+
+const mockLog = jest.fn();
+
+const baseOptions = {
+    style: {
+        layout: 'text',
+        logo: { type: 'primary', position: 'left' },
+        text: { size: 12 }
+    }
+};
+
+const baseV2Content = {
+    meta: { offerCountry: 'US' },
+    main_items: [{ type: 'text', content: 'Pay Later' }],
+    action_items: [{ type: 'text', content: 'Learn more' }],
+    disclaimer_items: [{ type: 'text', content: 'Subject to approval.' }]
+};
+
+describe('v2 render', () => {
+    beforeEach(() => {
+        mockLog.mockClear();
+    });
+
+    test('returns an HTML string', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(typeof result).toBe('string');
+        expect(result.length).toBeGreaterThan(0);
+    });
+
+    test('renders main_items text content', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('Pay Later');
+    });
+
+    test('renders action_items content', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('Learn more');
+    });
+
+    test('renders disclaimer_items content', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('Subject to approval.');
+    });
+
+    test('renders message container structure', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('class="message"');
+        expect(result).toContain('message__container');
+        expect(result).toContain('message__content');
+    });
+
+    test('includes locale class from meta.offerCountry', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('locale--US');
+    });
+
+    test('uses GB locale class when offerCountry is GB', () => {
+        const content = { ...baseV2Content, meta: { offerCountry: 'GB' } };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toContain('locale--GB');
+    });
+
+    test('renders logo item for type logo', () => {
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'logo', src: 'https://example.com/logo.svg', dimensions: [60, 20], alt: 'PayPal' },
+                { type: 'text', content: 'Pay Later' }
+            ]
+        };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toContain('message__logo-container');
+        expect(result).toContain('https://example.com/logo.svg');
+    });
+
+    test('renders inline logo inline with text', () => {
+        const options = { style: { ...baseOptions.style, logo: { type: 'inline' } } };
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'text', content: 'Pay Later' },
+                { type: 'logo', src: 'https://example.com/logo.svg', dimensions: [60, 20] }
+            ]
+        };
+        const result = render(options, content, mockLog);
+        expect(result).toContain('message__logo-container');
+    });
+
+    test('handles empty main_items gracefully', () => {
+        const content = { ...baseV2Content, main_items: [] };
+        const result = render(baseOptions, content, mockLog);
+        expect(typeof result).toBe('string');
+    });
+
+    test('omits action_items section when empty', () => {
+        const content = { ...baseV2Content, action_items: [] };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).not.toContain('class="message__sub-headline"');
+    });
+
+    test('omits disclaimer section when empty', () => {
+        const content = { ...baseV2Content, disclaimer_items: [] };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).not.toContain('class="message__disclaimer"');
+    });
+
+    test('handles missing v2Content fields gracefully', () => {
+        const result = render(baseOptions, {}, mockLog);
+        expect(typeof result).toBe('string');
+    });
+
+    test('renders flex layout', () => {
+        const options = { style: { layout: 'flex', color: 'blue', ratio: '8x1' } };
+        const result = render(options, baseV2Content, mockLog);
+        expect(result).toContain('class="message"');
+    });
+});

--- a/tests/unit/spec/server/v2/render.test.js
+++ b/tests/unit/spec/server/v2/render.test.js
@@ -1,20 +1,12 @@
 import render from 'server/v2/render';
 
-jest.mock('server/message/styles', () => ({
-    __esModule: true,
-    default: {
-        'layout:text': [['default', '.message { display: block; }']],
-        'layout:flex': [['default', '.message { display: flex; }']]
-    }
-}));
-
 const mockLog = jest.fn();
 
 const baseOptions = {
     style: {
         layout: 'text',
         logo: { type: 'primary', position: 'left' },
-        text: { size: 12 }
+        text: { color: 'black', size: 12 }
     }
 };
 
@@ -26,73 +18,144 @@ const baseV2Content = {
 };
 
 describe('v2 render', () => {
-    beforeEach(() => {
-        mockLog.mockClear();
-    });
-
     test('returns an HTML string', () => {
         const result = render(baseOptions, baseV2Content, mockLog);
         expect(typeof result).toBe('string');
         expect(result.length).toBeGreaterThan(0);
     });
 
-    test('renders main_items text content', () => {
+    test('renders pp-message root element', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('class="pp-message"');
+    });
+
+    test('includes inline style tag', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toContain('<style');
+        expect(result).toContain('pp-message');
+    });
+
+    test('renders main_items text in .main span', () => {
         const result = render(baseOptions, baseV2Content, mockLog);
         expect(result).toContain('Pay Later');
+        expect(result).toMatch(/class="main[^"]*"/);
     });
 
-    test('renders action_items content', () => {
+    test('main span has aria-label', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).toMatch(/aria-label="[^"]+"/);
+    });
+
+    test('renders action_items in .action span', () => {
         const result = render(baseOptions, baseV2Content, mockLog);
         expect(result).toContain('Learn more');
+        expect(result).toMatch(/class="action[^"]*"/);
     });
 
-    test('renders disclaimer_items content', () => {
+    test('renders disclaimer_items appended to main content', () => {
         const result = render(baseOptions, baseV2Content, mockLog);
         expect(result).toContain('Subject to approval.');
     });
 
-    test('renders message container structure', () => {
-        const result = render(baseOptions, baseV2Content, mockLog);
-        expect(result).toContain('class="message"');
-        expect(result).toContain('message__container');
-        expect(result).toContain('message__content');
-    });
-
-    test('includes locale class from meta.offerCountry', () => {
-        const result = render(baseOptions, baseV2Content, mockLog);
-        expect(result).toContain('locale--US');
-    });
-
-    test('uses GB locale class when offerCountry is GB', () => {
-        const content = { ...baseV2Content, meta: { offerCountry: 'GB' } };
+    test('omits action span when action_items is empty', () => {
+        const content = { ...baseV2Content, action_items: [] };
         const result = render(baseOptions, content, mockLog);
-        expect(result).toContain('locale--GB');
+        expect(result).not.toMatch(/class="action[^"]*"/);
     });
 
-    test('renders logo item for type logo', () => {
+    test('renders logo item as img in .logo span', () => {
         const content = {
             ...baseV2Content,
             main_items: [
-                { type: 'logo', src: 'https://example.com/logo.svg', dimensions: [60, 20], alt: 'PayPal' },
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
                 { type: 'text', content: 'Pay Later' }
             ]
         };
         const result = render(baseOptions, content, mockLog);
-        expect(result).toContain('message__logo-container');
         expect(result).toContain('https://example.com/logo.svg');
+        expect(result).toMatch(/class="logo[^"]*"/);
+        expect(result).toContain('role="img"');
     });
 
-    test('renders inline logo inline with text', () => {
-        const options = { style: { ...baseOptions.style, logo: { type: 'inline' } } };
+    test('positions logo on left by default', () => {
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
+                { type: 'text', content: 'Pay Later' }
+            ]
+        };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toMatch(/class="logo[^"]*left[^"]*"/);
+    });
+
+    test('positions logo on right when position is right', () => {
+        const options = { style: { ...baseOptions.style, logo: { type: 'primary', position: 'right' } } };
         const content = {
             ...baseV2Content,
             main_items: [
                 { type: 'text', content: 'Pay Later' },
-                { type: 'logo', src: 'https://example.com/logo.svg', dimensions: [60, 20] }
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' }
             ]
         };
         const result = render(options, content, mockLog);
-        expect(result).toContain('message__logo-container');
+        expect(result).toMatch(/class="logo[^"]*right[^"]*"/);
+    });
+
+    test('positions logo on top when position is top', () => {
+        const options = { style: { ...baseOptions.style, logo: { type: 'primary', position: 'top' } } };
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
+                { type: 'text', content: 'Pay Later' }
+            ]
+        };
+        const result = render(options, content, mockLog);
+        expect(result).toMatch(/class="logo[^"]*top[^"]*"/);
+    });
+
+    test('inline logo type keeps logo in main blocks without a standalone logo span', () => {
+        const options = { style: { ...baseOptions.style, logo: { type: 'inline', position: 'left' } } };
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'text', content: 'Pay Later' },
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' }
+            ]
+        };
+        const result = render(options, content, mockLog);
+        // no standalone logo span — logo rendered inline within main blocks
+        expect(result).not.toMatch(/role="img"/);
+    });
+
+    test('logo type none suppresses logo span even when logo item is present', () => {
+        const options = { style: { ...baseOptions.style, logo: { type: 'none', position: 'left' } } };
+        const content = {
+            ...baseV2Content,
+            main_items: [
+                { type: 'logo', src: 'https://example.com/logo.svg', alt: 'PayPal' },
+                { type: 'text', content: 'Pay Later' }
+            ]
+        };
+        const result = render(options, content, mockLog);
+        expect(result).not.toMatch(/role="img"/);
+    });
+
+    test('renders link item as an anchor tag', () => {
+        const content = {
+            ...baseV2Content,
+            main_items: [{ type: 'link', content: 'Terms apply' }]
+        };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toContain('<a');
+        expect(result).toContain('Terms apply');
+    });
+
+    test('applies text color class to main span', () => {
+        const options = { style: { ...baseOptions.style, text: { color: 'white' } } };
+        const result = render(options, baseV2Content, mockLog);
+        expect(result).toMatch(/class="main[^"]*white[^"]*"/);
     });
 
     test('handles empty main_items gracefully', () => {
@@ -101,26 +164,16 @@ describe('v2 render', () => {
         expect(typeof result).toBe('string');
     });
 
-    test('omits action_items section when empty', () => {
-        const content = { ...baseV2Content, action_items: [] };
-        const result = render(baseOptions, content, mockLog);
-        expect(result).not.toContain('class="message__sub-headline"');
-    });
-
-    test('omits disclaimer section when empty', () => {
-        const content = { ...baseV2Content, disclaimer_items: [] };
-        const result = render(baseOptions, content, mockLog);
-        expect(result).not.toContain('class="message__disclaimer"');
-    });
-
     test('handles missing v2Content fields gracefully', () => {
         const result = render(baseOptions, {}, mockLog);
         expect(typeof result).toBe('string');
+        expect(result).toContain('class="pp-message"');
     });
 
-    test('renders flex layout', () => {
-        const options = { style: { layout: 'flex', color: 'blue', ratio: '8x1' } };
-        const result = render(options, baseV2Content, mockLog);
-        expect(result).toContain('class="message"');
+    test('does not use v5 cascade structure', () => {
+        const result = render(baseOptions, baseV2Content, mockLog);
+        expect(result).not.toContain('message__container');
+        expect(result).not.toContain('message__headline');
+        expect(result).not.toContain('message__foreground');
     });
 });

--- a/tests/unit/spec/server/v2/render.test.js
+++ b/tests/unit/spec/server/v2/render.test.js
@@ -152,6 +152,24 @@ describe('v2 render', () => {
         expect(result).toContain('Terms apply');
     });
 
+    test('uses item.href on link items when present', () => {
+        const content = {
+            ...baseV2Content,
+            main_items: [{ type: 'link', content: 'Terms apply', href: 'https://example.com/terms' }]
+        };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toContain('href="https://example.com/terms"');
+    });
+
+    test('falls back to # when link item has no href', () => {
+        const content = {
+            ...baseV2Content,
+            main_items: [{ type: 'link', content: 'Terms apply' }]
+        };
+        const result = render(baseOptions, content, mockLog);
+        expect(result).toContain('href="#"');
+    });
+
     test('applies text color class to main span', () => {
         const options = { style: { ...baseOptions.style, text: { color: 'white' } } };
         const result = render(options, baseV2Content, mockLog);

--- a/tests/unit/spec/server/v2/utils.test.js
+++ b/tests/unit/spec/server/v2/utils.test.js
@@ -25,32 +25,32 @@ describe('mapClasses', () => {
 });
 
 describe('buildContentLabel', () => {
-    test('joins content fields from text items', () => {
+    test('joins text fields from TEXT items', () => {
         const items = [
-            { type: 'text', content: 'Pay Later' },
-            { type: 'text', content: 'with PayPal' }
+            { type: 'TEXT', text: 'Pay Later' },
+            { type: 'TEXT', text: 'with PayPal' }
         ];
         expect(buildContentLabel(items)).toBe('Pay Later with PayPal');
     });
 
-    test('uses alt field for image items', () => {
+    test('uses alternative_text field for IMAGE items', () => {
         const items = [
-            { type: 'logo', alt: 'PayPal logo' },
-            { type: 'text', content: 'Pay Later' }
+            { type: 'IMAGE', alternative_text: 'PayPal logo', source_url: 'logo.svg' },
+            { type: 'TEXT', text: 'Pay Later' }
         ];
         expect(buildContentLabel(items)).toBe('PayPal logo Pay Later');
     });
 
-    test('filters empty content', () => {
+    test('filters empty text', () => {
         const items = [
-            { type: 'text', content: '' },
-            { type: 'text', content: 'Pay Later' }
+            { type: 'TEXT', text: '' },
+            { type: 'TEXT', text: 'Pay Later' }
         ];
         expect(buildContentLabel(items)).toBe('Pay Later');
     });
 
     test('trims whitespace from each item', () => {
-        const items = [{ type: 'text', content: '  Pay Later  ' }];
+        const items = [{ type: 'TEXT', text: '  Pay Later  ' }];
         expect(buildContentLabel(items)).toBe('Pay Later');
     });
 
@@ -60,10 +60,10 @@ describe('buildContentLabel', () => {
 });
 
 describe('buildLogoConfiguration', () => {
-    const logoItem = { type: 'logo', src: 'logo.svg' };
-    const textItem = { type: 'text', content: 'Pay Later' };
+    const logoItem = { type: 'IMAGE', source_url: 'logo.svg', alternative_text: 'PayPal', name: 'paypal_logo' };
+    const textItem = { type: 'TEXT', text: 'Pay Later' };
 
-    test('extracts logo block and filters from mainBlocks for left position', () => {
+    test('extracts IMAGE block and filters from mainBlocks for left position', () => {
         const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [logoItem, textItem] });
         expect(result.logoBlock).toBe(logoItem);
         expect(result.mainBlocks).toEqual([textItem]);
@@ -91,14 +91,7 @@ describe('buildLogoConfiguration', () => {
         expect(result.logoBlock).toBeUndefined();
     });
 
-    test('handles image type same as logo type', () => {
-        const imageItem = { type: 'image', src: 'logo.png' };
-        const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [imageItem, textItem] });
-        expect(result.logoBlock).toBe(imageItem);
-        expect(result.mainBlocks).toEqual([textItem]);
-    });
-
-    test('returns no logo block when no logo items present', () => {
+    test('returns no logo block when no IMAGE items present', () => {
         const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [textItem] });
         expect(result.logoBlock).toBeUndefined();
         expect(result.hasInitialLogo).toBe(false);

--- a/tests/unit/spec/server/v2/utils.test.js
+++ b/tests/unit/spec/server/v2/utils.test.js
@@ -1,0 +1,107 @@
+import { mapClasses } from 'server/v2/utils/mapClasses';
+import { buildContentLabel } from 'server/v2/utils/buildContentLabel';
+import { buildLogoConfiguration } from 'server/v2/utils/buildLogoConfiguration';
+
+describe('mapClasses', () => {
+    test('joins truthy entries as space-separated string', () => {
+        expect(mapClasses({ main: true, left: true, black: true })).toBe('main left black');
+    });
+
+    test('excludes falsy entries', () => {
+        expect(mapClasses({ main: true, right: false, black: true })).toBe('main black');
+    });
+
+    test('lowercases and replaces underscores with dashes', () => {
+        expect(mapClasses({ LOGO_TYPE: true })).toBe('logo-type');
+    });
+
+    test('excludes empty string keys', () => {
+        expect(mapClasses({ '': true, main: true })).toBe('main');
+    });
+
+    test('returns empty string when all entries are falsy', () => {
+        expect(mapClasses({ main: false, action: false })).toBe('');
+    });
+});
+
+describe('buildContentLabel', () => {
+    test('joins content fields from text items', () => {
+        const items = [
+            { type: 'text', content: 'Pay Later' },
+            { type: 'text', content: 'with PayPal' }
+        ];
+        expect(buildContentLabel(items)).toBe('Pay Later with PayPal');
+    });
+
+    test('uses alt field for image items', () => {
+        const items = [
+            { type: 'logo', alt: 'PayPal logo' },
+            { type: 'text', content: 'Pay Later' }
+        ];
+        expect(buildContentLabel(items)).toBe('PayPal logo Pay Later');
+    });
+
+    test('filters empty content', () => {
+        const items = [
+            { type: 'text', content: '' },
+            { type: 'text', content: 'Pay Later' }
+        ];
+        expect(buildContentLabel(items)).toBe('Pay Later');
+    });
+
+    test('trims whitespace from each item', () => {
+        const items = [{ type: 'text', content: '  Pay Later  ' }];
+        expect(buildContentLabel(items)).toBe('Pay Later');
+    });
+
+    test('returns empty string for empty array', () => {
+        expect(buildContentLabel([])).toBe('');
+    });
+});
+
+describe('buildLogoConfiguration', () => {
+    const logoItem = { type: 'logo', src: 'logo.svg' };
+    const textItem = { type: 'text', content: 'Pay Later' };
+
+    test('extracts logo block and filters from mainBlocks for left position', () => {
+        const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [logoItem, textItem] });
+        expect(result.logoBlock).toBe(logoItem);
+        expect(result.mainBlocks).toEqual([textItem]);
+        expect(result.hasInitialLogo).toBe(true);
+        expect(result.hasRightLogo).toBe(false);
+    });
+
+    test('sets hasRightLogo for right position', () => {
+        const result = buildLogoConfiguration({ logoPosition: 'right', mainItems: [textItem, logoItem] });
+        expect(result.hasRightLogo).toBe(true);
+        expect(result.hasInitialLogo).toBe(false);
+    });
+
+    test('sets hasInitialLogo for top position', () => {
+        const result = buildLogoConfiguration({ logoPosition: 'top', mainItems: [logoItem, textItem] });
+        expect(result.hasInitialLogo).toBe(true);
+        expect(result.hasRightLogo).toBe(false);
+    });
+
+    test('inline position keeps all items in mainBlocks', () => {
+        const result = buildLogoConfiguration({ logoPosition: 'inline', mainItems: [logoItem, textItem] });
+        expect(result.mainBlocks).toEqual([logoItem, textItem]);
+        expect(result.hasInitialLogo).toBe(false);
+        expect(result.hasRightLogo).toBe(false);
+        expect(result.logoBlock).toBeUndefined();
+    });
+
+    test('handles image type same as logo type', () => {
+        const imageItem = { type: 'image', src: 'logo.png' };
+        const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [imageItem, textItem] });
+        expect(result.logoBlock).toBe(imageItem);
+        expect(result.mainBlocks).toEqual([textItem]);
+    });
+
+    test('returns no logo block when no logo items present', () => {
+        const result = buildLogoConfiguration({ logoPosition: 'left', mainItems: [textItem] });
+        expect(result.logoBlock).toBeUndefined();
+        expect(result.hasInitialLogo).toBe(false);
+        expect(result.mainBlocks).toEqual([textItem]);
+    });
+});

--- a/tests/unit/spec/server/v2/validateStyle.test.js
+++ b/tests/unit/spec/server/v2/validateStyle.test.js
@@ -1,0 +1,70 @@
+import validateStyle from 'server/v2/validateStyle';
+
+const mockLog = jest.fn();
+
+describe('v2 validateStyle', () => {
+    beforeEach(() => {
+        mockLog.mockClear();
+    });
+
+    test('returns validated text layout with defaults', () => {
+        const result = validateStyle(mockLog, { layout: 'text' });
+        expect(result.layout).toBe('text');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('returns validated flex layout with defaults', () => {
+        const result = validateStyle(mockLog, { layout: 'flex' });
+        expect(result.layout).toBe('flex');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('falls back to text layout and logs for unknown layout', () => {
+        const result = validateStyle(mockLog, { layout: 'unknown' });
+        expect(result.layout).toBe('text');
+        expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    test('maps custom layout to text and logs a warning', () => {
+        const result = validateStyle(mockLog, { layout: 'custom' });
+        expect(result.layout).toBe('text');
+        expect(mockLog).toHaveBeenCalledTimes(1);
+        expect(mockLog.mock.calls[0][0]).toMatch(/custom/);
+    });
+
+    test('logs and corrects invalid logo.type for text layout', () => {
+        const result = validateStyle(mockLog, { layout: 'text', logo: { type: 'invalid' } });
+        expect(mockLog).toHaveBeenCalledTimes(1);
+        expect(result.logo.type).toBe('primary');
+    });
+
+    test('accepts valid logo.type values for text layout', () => {
+        ['primary', 'alternative', 'inline', 'none'].forEach(type => {
+            mockLog.mockClear();
+            const result = validateStyle(mockLog, { layout: 'text', logo: { type } });
+            expect(result.logo.type).toBe(type);
+            expect(mockLog).not.toHaveBeenCalled();
+        });
+    });
+
+    test('normalises greyscale alias for text layout text.color', () => {
+        const result = validateStyle(mockLog, { layout: 'text', text: { color: 'greyscale' } });
+        expect(result.text.color).toBe('grayscale');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('accepts valid flex layout color values', () => {
+        ['blue', 'black', 'white', 'gray', 'monochrome', 'grayscale'].forEach(color => {
+            mockLog.mockClear();
+            const result = validateStyle(mockLog, { layout: 'flex', color });
+            expect(result.color).toBe(color);
+            expect(mockLog).not.toHaveBeenCalled();
+        });
+    });
+
+    test('normalises grey alias for flex layout color', () => {
+        const result = validateStyle(mockLog, { layout: 'flex', color: 'grey' });
+        expect(result.color).toBe('gray');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/spec/server/v2/validateStyle.test.js
+++ b/tests/unit/spec/server/v2/validateStyle.test.js
@@ -13,6 +13,24 @@ describe('v2 validateStyle', () => {
         expect(mockLog).not.toHaveBeenCalled();
     });
 
+    test('defaults missing layout to text without logging', () => {
+        const result = validateStyle(mockLog, {});
+        expect(result.layout).toBe('text');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('defaults missing style to text without logging', () => {
+        const result = validateStyle(mockLog);
+        expect(result.layout).toBe('text');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('defaults null style to text without logging', () => {
+        const result = validateStyle(mockLog, null);
+        expect(result.layout).toBe('text');
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
     test('returns validated flex layout with defaults', () => {
         const result = validateStyle(mockLog, { layout: 'flex' });
         expect(result.layout).toBe('flex');

--- a/tests/unit/spec/server/v2/validateStyle.test.js
+++ b/tests/unit/spec/server/v2/validateStyle.test.js
@@ -67,4 +67,11 @@ describe('v2 validateStyle', () => {
         expect(result.color).toBe('gray');
         expect(mockLog).not.toHaveBeenCalled();
     });
+
+    test('logs type mismatch and falls back to default when wrong type is passed', () => {
+        const result = validateStyle(mockLog, { layout: 'text', logo: { type: 123 } });
+        expect(mockLog).toHaveBeenCalledTimes(1);
+        expect(mockLog.mock.calls[0][0]).toMatch(/expected type/i);
+        expect(result.logo.type).toBe('primary');
+    });
 });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -155,5 +155,28 @@ module.exports = (env = {}) => {
         })
     });
 
-    return [LIBRARY_DEV_CONFIG, COMPONENTS_DEV_CONFIG, LANDER_COMPONENTS_DEV_CONFIG, RENDERING_DEV_CONFIG];
+    const RENDERING_V2_DEV_CONFIG = getWebpackConfig({
+        entry: {
+            renderV2Message: './src/server/v2/index.js'
+        },
+        libraryTarget: 'commonjs',
+        modulename: 'renderV2Message',
+        debug: true,
+        minify: false,
+        sourcemaps: false,
+        filename: '[name].js',
+        env: env.NODE_ENV,
+        vars: globals({
+            ...env,
+            TARGET: 'render'
+        })
+    });
+
+    return [
+        LIBRARY_DEV_CONFIG,
+        COMPONENTS_DEV_CONFIG,
+        LANDER_COMPONENTS_DEV_CONFIG,
+        RENDERING_DEV_CONFIG,
+        RENDERING_V2_DEV_CONFIG
+    ];
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,10 +97,26 @@ module.exports = (env = {}) => {
         })
     });
 
+    const RENDERING_V2_CONFIG = getWebpackConfig({
+        entry: {
+            renderV2Message: './src/server/v2/index.js'
+        },
+        libraryTarget: 'commonjs',
+        modulename: 'renderV2Message',
+        minify: true,
+        debug: false,
+        filename: '[name].js',
+        env: env.NODE_ENV,
+        vars: globals({
+            ...env,
+            TARGET: 'render'
+        })
+    });
+
     const modules = {
         library: [MESSAGING_JS_CONFIG, MODAL_JS_CONFIG],
         components: [COMPONENTS_CONFIG, LANDER_COMPONENTS_CONFIG],
-        render: [RENDERING_CONFIG]
+        render: [RENDERING_CONFIG, RENDERING_V2_CONFIG]
     };
 
     return Array.prototype.concat.apply(


### PR DESCRIPTION
## Description

Adds \`renderV2Message.js\` SSR bundle (sibling to \`renderMessage.js\`) that renders CPS v2 presentment content (\`main_items\`, \`action_items\`, \`disclaimer_items\`) directly without transforming to the legacy v5 schema.

The renderer follows the v6 message template architecture ported to Preact: explicit content block switching (TEXT, IMAGE, LINK), simple class mapping via \`mapClasses\`, and a small static style surface — no \`applyCascade\`, no locale mutation rules, no v5 cascade complexity.

\`src/server/v2/\` is fully independent of the v5 rendering flow — no imports from \`../\` (v5) files.

Exports \`render\`, \`validateStyle\`, \`getParentStyles\`, and \`version\` so \`crcpresentmentnodeweb\` can load it behind the \`credit_upstream_v5_sdk_rewrite\` ELMO treatment.

## Changes

- \`src/server/v2/\` — new SSR module (render, message, validateStyle, validOptions, getParentStyles, styles, types, constants, utils)
- \`webpack.config.js\` / \`webpack.config.dev.js\` — \`renderV2Message\` build entry (prod + dev)
- \`scripts/smoke-test-v2-bundle.js\` — exercises the bundle like CPNW would (no CPNW dependency needed)
- \`scripts/preview-v2-render.js\` — local browser preview from CDN stage bundle

## Testing

Unit tests (51 pass):
\`\`\`
npx jest --testPathPattern="server/v2"
\`\`\`

Stage bundle smoke test:
\`\`\`
node scripts/smoke-test-v2-bundle.js render_v2_msg
\`\`\`

Local browser preview:
\`\`\`
node scripts/preview-v2-render.js render_v2_msg
\`\`\`