### PR TITLE
fix: AT modal amount formatting

### DIFF
--- a/src/components/modal/v2/parts/OfferAccordion.jsx
+++ b/src/components/modal/v2/parts/OfferAccordion.jsx
@@ -1,6 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
+import { delocalize, localize } from '../lib';
 import Icon from './Icon';
 
 const OfferAccordion = ({
@@ -17,11 +18,15 @@ const OfferAccordion = ({
     const { termsLabel } = content;
     const currencySymbolFormat = str => {
         let result = str?.replace(/(\s?EUR)/g, ' €') ?? '';
-        if (offerCountry === 'AT') {
-            // MORS provides currency-formatted strings (e.g. "1.000,00 EUR") where period is the
-            // thousands separator for de-AT currency style. The input field uses de-AT number style
-            // (narrow no-break space U+202F as thousands separator). Reformat to match.
-            result = result.replace(/(\d)\.(\d{3})/g, '$1 $2');
+        if (offerCountry === 'AT' && result) {
+            // Reformat the numeric part using the locale's number style so the thousands separator
+            // matches what the calculator input field displays (de-AT number format uses narrow
+            // no-break space, whereas de-AT currency format uses period).
+            const withoutSymbol = result.replace(/\s*€/, '').trim();
+            const numericValue = parseFloat(delocalize(withoutSymbol, offerCountry));
+            if (!Number.isNaN(numericValue)) {
+                result = `${localize(numericValue, offerCountry, 2)} €`;
+            }
         }
         return result;
     };

--- a/src/components/modal/v2/parts/OfferAccordion.jsx
+++ b/src/components/modal/v2/parts/OfferAccordion.jsx
@@ -16,7 +16,14 @@ const OfferAccordion = ({
     const [open, setOpen] = useState('');
     const { termsLabel } = content;
     const currencySymbolFormat = str => {
-        return str.replace(/(\s?EUR)/g, ' €');
+        let result = str?.replace(/(\s?EUR)/g, ' €') ?? '';
+        if (offerCountry === 'AT') {
+            // MORS provides currency-formatted strings (e.g. "1.000,00 EUR") where period is the
+            // thousands separator for de-AT currency style. The input field uses de-AT number style
+            // (narrow no-break space U+202F as thousands separator). Reformat to match.
+            result = result.replace(/(\d)\.(\d{3})/g, '$1 $2');
+        }
+        return result;
     };
 
     useEffect(() => {


### PR DESCRIPTION
## Description

**Problem fixed**: In Austrian (AT) modals, the amount displayed in the offer accordion used a
  different thousands-separator format than the calculator input field. The EUR currency format in
  de-AT uses a period as the thousands separator, while the number format uses a narrow no-break
  space — causing a visual mismatch.
  
  As a temporary fix, used localize lib for AT to re-format as number style instead of currency.

## Screenshots / Videos

<img width="1009" height="1117" alt="Noch heute kaufen - ohne Anzahlung" src="https://github.com/user-attachments/assets/7e86a44f-93fd-4c14-ae55-6d10c169c739" />

<img width="1004" height="1121" alt="päter bezahlen in" src="https://github.com/user-attachments/assets/8e117d37-07e2-4c02-9083-acbac253eb59" />


## Testing instructions

https://www.te-upstream-at-expansion.qa.paypal.com/credit-presentment/lander/modal?customer_id=YSG9BQ5DWPD5E&offer=PAY_LATER_LONG_TERM&stageTag=atmodalformatting001&channel=PAY_LATER_HUB

stageTag - atmodalformatting001

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
