### PR TITLE
fix: adjust modal close button position on ios 26 webview

### DIFF
--- a/src/components/modal/v2/lib/utils.js
+++ b/src/components/modal/v2/lib/utils.js
@@ -79,6 +79,18 @@ export const isLander = __MESSAGES__.__TARGET__ === 'LANDER';
 const { userAgent } = window.navigator;
 export const isIframe = window.top !== window || isIosWebview(userAgent) || isAndroidWebview(userAgent);
 
+export function getIosMajorVersionFromUserAgent(ua = userAgent) {
+    const match = ua.match(/OS\s(\d+)[_.]/i);
+
+    if (!match) {
+        return null;
+    }
+
+    return Number.parseInt(match[1], 10);
+}
+
+export const isIos26Webview = isIosWebview(userAgent) && getIosMajorVersionFromUserAgent(userAgent) === 26;
+
 export function setupTabTrap() {
     // Disable tab trap functionality for modal lander
     if (isLander) {

--- a/src/components/modal/v2/parts/Modal.jsx
+++ b/src/components/modal/v2/parts/Modal.jsx
@@ -1,7 +1,14 @@
 /** @jsx h */
 import { h } from 'preact';
 
-import { TransitionStateProvider, XPropsProvider, ServerDataProvider, isLander, isIframe } from '../lib';
+import {
+    TransitionStateProvider,
+    XPropsProvider,
+    ServerDataProvider,
+    isLander,
+    isIframe,
+    isIos26Webview
+} from '../lib';
 import ErrorBoundary from './ErrorBoundary';
 import Container from './Container';
 
@@ -10,7 +17,11 @@ import styles from '../styles/index.scss';
 // Add these classes to the root <html> element since we need lander specfic styles on it
 // We're safe to do this outside of a useEffect since the <html> element will already exist in the DOM
 // by the time this script executes.
-document.documentElement.className = [isLander && !isIframe && 'lander', isLander && isIframe && 'api-iframe']
+document.documentElement.className = [
+    isLander && !isIframe && 'lander',
+    isLander && isIframe && 'api-iframe',
+    isIos26Webview && 'ios26-webview'
+]
     .filter(Boolean)
     .join(' ');
 

--- a/src/components/modal/v2/styles/components/_header.scss
+++ b/src/components/modal/v2/styles/components/_header.scss
@@ -503,3 +503,10 @@
         }
     }
 }
+
+html.ios26-webview {
+    .header__fixed-wrapper,
+    .header__icons {
+        top: env(safe-area-inset-top, 0px);
+    }
+}

--- a/tests/unit/spec/src/components/modal/v2/lib/utils.test.js
+++ b/tests/unit/spec/src/components/modal/v2/lib/utils.test.js
@@ -1,4 +1,9 @@
-import { formatDateByCountry, validateProps, openPrequalification } from 'src/components/modal/v2/lib/utils';
+import {
+    formatDateByCountry,
+    validateProps,
+    openPrequalification,
+    getIosMajorVersionFromUserAgent
+} from 'src/components/modal/v2/lib/utils';
 
 jest.mock('src/utils', () => {
     const original = jest.requireActual('src/utils');
@@ -94,5 +99,23 @@ describe('openPrequalification', () => {
         expect(window.location.assign).toHaveBeenCalledWith(
             'https://www.paypal.com/paylateracq/prequalify?token=&offer=PAY_LATER_SHORT_TERM'
         );
+    });
+});
+
+describe('getIosMajorVersionFromUserAgent', () => {
+    it('returns iOS major version when UA has iOS version token', () => {
+        const version = getIosMajorVersionFromUserAgent(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+        );
+
+        expect(version).toBe(26);
+    });
+
+    it('returns null when UA does not have iOS version token', () => {
+        const version = getIosMajorVersionFromUserAgent(
+            'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/125.0 Mobile Safari/537.36'
+        );
+
+        expect(version).toBeNull();
     });
 });


### PR DESCRIPTION
## Description
on iOS 26 devices with Dynamic Island the close button (X) on the PayPal "Pay in 3 installments" modal is not clickable on iOS 26 devices when opened from within a Capacitor-based WKWebView application. The button appears in the upper right corner of the screen, overlapping with the iOS status bar and Dynamic Island area, making it unresponsive to touch events.

## Screenshots / Videos
N/A

## Testing instructions
N/A

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
