### PR TITLE
fix iOS overlay

### DIFF
--- a/src/components/modal/v2/styles/components/_modal-frame.scss
+++ b/src/components/modal/v2/styles/components/_modal-frame.scss
@@ -4,7 +4,7 @@
 .modal-wrapper {
     display: flex;
     position: absolute;
-    top: env(safe-area-inset-right, 0px);
+    top: env(safe-area-inset-top, 0px);
     left: 0;
     width: 100%;
     height: 100%;

--- a/src/components/modal/v2/styles/components/_modal-frame.scss
+++ b/src/components/modal/v2/styles/components/_modal-frame.scss
@@ -4,7 +4,7 @@
 .modal-wrapper {
     display: flex;
     position: absolute;
-    top: 0;
+    top: env(safe-area-inset-right, 0px);
     left: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
## Description
The PayPal JavaScript SDK generates a full-screen iframe/overlay modal that does not properly account for iOS safe area insets in WKWebView environments on iOS 26. The X button is positioned at top: 0, overlapping with the iOS status bar/Dynamic Island area, and does not respond to touch events. Modal cannot be dismissed.

## Screenshots / Videos
https://platform.applause.com/services/links/v1/external/403be9247dfd7653148cde54ea761a10ad80d969b61944eb97a82cd7956122db

## Testing instructions
N/A

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
