### PR TITLE
fix: prevent treatments features object serialization

### DIFF
--- a/src/library/zoid/treatments/component.js
+++ b/src/library/zoid/treatments/component.js
@@ -48,6 +48,10 @@ function getTreatmentPayerId() {
     return account && !account.startsWith(CLIENT_ID_ACCOUNT_PREFIX) ? account : undefined;
 }
 
+function getTreatmentFeatures({ props = {} }) {
+    return getFeatures(typeof props.features === 'string' ? props.features : undefined);
+}
+
 export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
     create({
         tag: TAG.TREATEMENTS,
@@ -86,7 +90,7 @@ export default createGlobalVariableGetter('__paypal_credit_treatments__', () =>
                 type: 'string',
                 queryParam: 'features',
                 required: false,
-                value: getFeatures
+                value: getTreatmentFeatures
             },
             namespace: {
                 type: 'string',

--- a/tests/unit/spec/src/zoid/treatments/component.test.js
+++ b/tests/unit/spec/src/zoid/treatments/component.test.js
@@ -104,6 +104,15 @@ describe('treatments component', () => {
         expect(treatmentsComponent.props.payerId).toBeUndefined();
     });
 
+    test('does not stringify zoid value options into features', () => {
+        const treatmentsComponent = getTreatmentsComponent();
+
+        expect(treatmentsComponent.props.features).toBe('native-modal');
+        expect(treatmentsComponent.config.props.features.value({ props: { features: 'test-feature' } })).toBe(
+            'test-feature,native-modal'
+        );
+    });
+
     test('handles treatment data', () => {
         const {
             props: { onReady }


### PR DESCRIPTION
## Description

Fixes the treatments Zoid `features` prop so it reads `props.features` from Zoid value options before calling `getFeatures`. Previously `value: getFeatures` received the whole Zoid value-options object and could stringify it into `[object Object],native-modal` in the treatments iframe query.

## Screenshots / Videos

N/A

## Testing instructions

- `npm test -- --runTestsByPath tests/unit/spec/src/zoid/treatments/component.test.js`
- `npx eslint src/library/zoid/treatments/component.js tests/unit/spec/src/zoid/treatments/component.test.js`
- `git diff --check`
- `npm run lint`
- `npm test`

## Review

Ready for initial review.
