### PR TITLE
fix: continue to use node 20 not 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
     main:
         runs-on: ubuntu-latest
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
         steps:
             - name: ⬇️ Checkout repo
               uses: actions/checkout@v4


### PR DESCRIPTION
## Description
continue to use node 20 not 24 in github actions publish workflow

## Screenshots / Videos
N/A

## Testing instructions
N/A

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
