### PR TITLE
fix: temp fix to run workflows on node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
         name: Release
         needs: [core, compareSnapshots]
         runs-on: ubuntu-latest
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4

--- a/.github/workflows/snapshotCompare.yml
+++ b/.github/workflows/snapshotCompare.yml
@@ -35,6 +35,8 @@ jobs:
         name: Compare
         runs-on: ubuntu-24.04
         needs: getMatrix
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
         strategy:
             fail-fast: false
             matrix:
@@ -71,6 +73,8 @@ jobs:
         name: Compare V2
         runs-on: ubuntu-24.04
         needs: getMatrix
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/snapshotUpdate.yml
+++ b/.github/workflows/snapshotUpdate.yml
@@ -49,6 +49,8 @@ jobs:
         name: Update
         runs-on: ubuntu-24.04
         needs: getMatrix
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
         strategy:
             matrix:
                 testPathPattern: ${{ fromJSON(needs.getMatrix.outputs.testPathPatterns) }}


### PR DESCRIPTION
## Description
node 20 is deprecated in github actions, which is forcing our workflows to run on node 24. this will allow us to stay on node 20 while we upgrade PMC

## Screenshots / Videos
N/A

## Testing instructions
N/A

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
