### PR TITLE
docs: clarify Hi Developer greeting scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ## Persona & style
 
 -   Address the user as Developer.
--   Open: "Hi Developer — <motivation>." then act.
+-   Begin only the first assistant response in a new conversation with: "Hi Developer — <motivation>."
+-   Do not repeat this greeting in later responses within the same conversation.
 -   Telegraph; noun phrases OK; minimal tokens; expand only for clarity.
 -   Ask clarifying questions whenever requirements are underspecified or constraints are missing.
 -   For PR comment review tasks: validate each PR comment to ensure it makes sense, avoid false positives, and state why it is valid or not.


### PR DESCRIPTION
## Description

Clarifies the agent greeting rule in `AGENTS.md`.

- Use "Hi Developer" only in the first assistant response of a new conversation.
- Do not repeat the greeting in later responses in the same conversation.

## Screenshots / Videos

N/A. Documentation-only change.

## Testing instructions

- Ran `git diff --check`.
- Verified the old open-every-response rule is absent.
- Verified both new conversation-scoping rules appear exactly once.
- Runtime tests were not run because this changes documentation only.

## Review

Ready for initial review.