### PR TITLE
fix: route PL_GENERIC_XB messageType to cross-border generic mutation

### DIFF
--- a/content/messages/AT/generic-non-at.json
+++ b/content/messages/AT/generic-non-at.json
@@ -2,7 +2,7 @@
     "meta": {
         "offerCountry": "AT",
         "offerType": "GENERIC",
-        "messageType": "GENERIC_XB",
+        "messageType": "PL_GENERIC_XB",
         "offerTerm": "{total_payments}",
         "lander": "",
         "variables": {

--- a/src/server/locale/AT/GPL/mutations/index.js
+++ b/src/server/locale/AT/GPL/mutations/index.js
@@ -36,7 +36,7 @@ export default function getMutations(id, type) {
         case 'PLLT_NQ_EZ':
             return gplEqz[type];
         case 'GENERIC:NON-AT':
-        case 'GENERIC_XB':
+        case 'PL_GENERIC_XB':
             return genericNonAt[type];
         case 'GENERIC':
         default:

--- a/src/server/locale/DE/GPL/mutations/index.js
+++ b/src/server/locale/DE/GPL/mutations/index.js
@@ -36,7 +36,7 @@ export default function getMutations(id, type) {
         case 'PLLT_NQ_EZ':
             return gplEqz[type];
         case 'GENERIC:NON-DE':
-        case 'GENERIC_XB':
+        case 'PL_GENERIC_XB':
             return genericNonDe[type];
         case 'GENERIC':
         default:


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Delete this comment so the preview begins with your description
    - Make sure not to include any internal links
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

<!-- Describe your changes and what problem they solve -->

Route PL_GENERIC_XB messageType to cross-border generic mutations for AT/DE.

Content service sends PL_GENERIC_XB in production but the mutation router only matched the legacy GENERIC_XB string, causing XB traffic to fall back to domestic mutations and drop the required cross-border disclaimer.

## Screenshots / Videos

<!-- Add any relevant screenshots, GIFs, or a short video demo. For non-UI changes, write "N/A". -->

Before fix

AT

<img width="1101" height="494" alt="Screenshot 2026-07-24 at 8 33 22 PM" src="https://github.com/user-attachments/assets/4c830f5a-4241-4eb3-8853-f77b8e06dd3d" />

DE

<img width="1081" height="439" alt="Screenshot 2026-07-24 at 8 34 47 PM" src="https://github.com/user-attachments/assets/7512b7a8-730e-457b-964d-2e7cca610d94" />

After fix

AT
<img width="890" height="359" alt="Screenshot 2026-07-24 at 8 36 04 PM" src="https://github.com/user-attachments/assets/2df7be14-4336-4a77-889a-3b8b6bbe6aeb" />


DE

<img width="1016" height="379" alt="Screenshot 2026-07-24 at 8 35 26 PM" src="https://github.com/user-attachments/assets/7588ed7b-86d0-4b43-8330-d54f6bd2e08a" />


## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->

Test env - te-upstream-at-expansion.qa.paypal.com
stageTag - atmessagingbug

https://young-anchorage-87182.herokuapp.com/pilot/stage/?account=3K9TYEU5P7FKJ&buyerCountry=AT&countryCode=AT&currency=EUR&language=de-AT&stageTag=atmessagingbug


## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

All pull requests require an initial review from your team followed by code owner approval.

While initial review is ongoing, please add the following label to your PR `Needs initial review`. This initial review process should ensure that:

-   Code follows team standards and best practices
-   Changes are thoroughly tested and verified
-   The PR template is filled out
-   Documentation is complete and accurate
-   The PR is ready for official code owner review

Once you have received initial approval, please do the following:

-   Remove the label `Needs initial review`
-   Add the label `Needs codeowner review`

Code owners will then review the PR in accordance with our SLA. This process helps maintain code quality and reduces review cycles.
