### PR TITLE
fix: fall back to server-resolved account for FPTI on credential-less landers

### DIFF
--- a/src/components/modal/v2/lib/zoid-polyfill.js
+++ b/src/components/modal/v2/lib/zoid-polyfill.js
@@ -51,7 +51,7 @@ export function handleBrowserEvents(clientOrigin, propListeners, event) {
     sendEvent(createPostMessengerEvent('ack', id), clientOrigin);
 }
 
-const getAccount = (merchantId, clientId, payerId) => {
+const getAccount = (merchantId, clientId, payerId, accountIdOverride) => {
     if (merchantId) {
         return merchantId;
     }
@@ -61,7 +61,12 @@ const getAccount = (merchantId, clientId, payerId) => {
         return `client-id:${clientId}`;
     }
 
-    return payerId;
+    if (payerId) {
+        return payerId;
+    }
+
+    // Server-resolved fallback for credential-less landers (no merchant_id/client_id/payer_id in the URL)
+    return accountIdOverride;
 };
 
 const setupBrowser = props => {
@@ -98,7 +103,7 @@ const setupBrowser = props => {
         // TODO: Verify these callbacks are instrumented correctly
         onReady: ({ products, meta }) => {
             const { clientId, payerId, merchantId, offer, partnerAttributionId } = props;
-            const { trackingDetails } = meta;
+            const { trackingDetails, accountIdOverride } = meta;
 
             logger.addMetaBuilder(existingMeta => {
                 // Remove potential existing meta info
@@ -124,7 +129,7 @@ const setupBrowser = props => {
                         // TODO: This should likely be specific to this integration type
                         type: 'modal',
                         // messageRequestId,
-                        account: getAccount(merchantId, clientId, payerId),
+                        account: getAccount(merchantId, clientId, payerId, accountIdOverride),
                         trackingDetails
                     }
                 };

--- a/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
+++ b/tests/unit/spec/src/components/modal/v2/lib/zoid-polyfill.test.js
@@ -8,6 +8,7 @@ jest.mock('src/utils', () => {
 
     return {
         ...originalModule,
+        getOrCreateDeviceID: jest.fn(() => 'mock-device-id'),
         logger: {
             track: jest.fn(),
             addMetaBuilder: jest.fn(),
@@ -354,6 +355,42 @@ describe('zoidPollyfill', () => {
             }
         `);
         postMessage.mockClear();
+    });
+
+    describe('getAccount falls back to a server-provided accountIdOverride when no URL ids are present', () => {
+        beforeAll(() => {
+            mockLoadUrl(
+                'https://localhost.paypal.com:8080/credit-presentment/lander/modal?offer=TIKTOK_PAYPAL_PAY_LATER_SHORT_TERM_US&channel=TIKTOK_MOBILE_APP'
+            );
+
+            zoidPolyfill();
+        });
+        beforeEach(() => {
+            logger.track.mockClear();
+            logger.addMetaBuilder.mockClear();
+        });
+
+        test('uses meta.accountIdOverride when merchantId/clientId/payerId are absent from the URL', () => {
+            window.xprops.onReady({
+                products: ['PAY_LATER_SHORT_TERM'],
+                meta: { trackingDetails: 'trackingDetails', accountIdOverride: 'W9WK2RH9RWWQC' }
+            });
+
+            expect(logger.track).toHaveBeenCalledTimes(1);
+            expect(logger.addMetaBuilder).toHaveBeenCalledTimes(1);
+            const metaBuilder = logger.addMetaBuilder.mock.calls[0][0];
+            expect(metaBuilder({})[1].account).toBe('W9WK2RH9RWWQC');
+        });
+
+        test('leaves account undefined when neither URL ids nor accountIdOverride are present', () => {
+            window.xprops.onReady({
+                products: ['PAY_LATER_SHORT_TERM'],
+                meta: { trackingDetails: 'trackingDetails' }
+            });
+
+            const metaBuilder = logger.addMetaBuilder.mock.calls[0][0];
+            expect(metaBuilder({})[1].account).toBeUndefined();
+        });
     });
 
     describe('notifies when props update', () => {


### PR DESCRIPTION

## Description

Credential-less lander modals (e.g. Pay Later Hub, and the upcoming TikTok Pay Later Hub) are loaded with a URL that has none of `merchant_id`, `client_id`, or `payer_id` — just an `offer`/`channel` pair. `getAccount()` in `zoid-polyfill.js` resolves the FPTI tracking "account" field exclusively from those three URL params; when all three are absent, the resolved account is empty, and the transport silently skips sending the tracking event entirely (no error, just zero requests). This means these lander flows produce **no FPTI tracking data today**.

This PR adds a fallback: `getAccount()` now also accepts a server-resolved `accountIdOverride` (delivered via the existing `serverData`/`meta` object already passed into the modal) and uses it when none of the URL-derived ids are present. This is purely additive — behavior is unchanged for any existing integration that already sends `merchant_id`/`client_id`/`payer_id`.

Note: this fix is inert on its own until paired with a small server-side change in the internal presentment service that actually populates `meta.accountIdOverride` (that service already resolves a usable fallback account for these channels for other purposes — it just isn't surfaced to the client yet). Landing this PR independently is safe either way since the new fallback parameter defaults to `undefined`, matching current behavior exactly.


## Screenshots / Videos


Working Tiktok PLH
<img width="432" height="737" alt="rendered-paylater-hub" src="https://github.com/user-attachments/assets/623db53b-3c89-475e-902f-ef7f377bdfd3" />




## Testing instructions

- Unit tests added in `zoid-polyfill.test.js` cover the new fallback path directly (falls back to `accountIdOverride` when `merchantId`/`clientId`/`payerId` are all absent; leaves `account` undefined when none are present, matching current behavior).
- End-to-end verification requires the paired server-side change to be deployed alongside this: load a credential-less lander URL with no `merchant_id`/`payer_id`/`client_id`, and confirm a tracking event now fires (previously zero events fired in this case).
