### PR TITLE
fix: remove long-term offers reversal for ES,IT,CA

### DIFF
--- a/src/components/modal/v2/parts/TermsTable.jsx
+++ b/src/components/modal/v2/parts/TermsTable.jsx
@@ -36,17 +36,13 @@ const TermsTable = ({
         );
     }
 
-    // ES, IT, and CA countries offer accordion should display in ascending order (6, 12, 24 months)
-    const processedOffers =
-        offerCountry === 'ES' || offerCountry === 'IT' || offerCountry === 'CA' ? [...offers].reverse() : offers;
-
-    const qualifyingOffers = processedOffers
+    const qualifyingOffers = offers
         .filter(offer => offer.meta.qualifying === 'true')
         .map((offer, idx) => {
             // DE, ES, and IT use the accordion style for presentation of offers in the modal.
             if (offerAccordionCountries.includes(offerCountry)) {
                 const disclaimer =
-                    aprDisclaimer.length < processedOffers.length
+                    aprDisclaimer.length < offers.length
                         ? aprDisclaimer[aprDisclaimer.length - 1].aprDisclaimer
                         : aprDisclaimer[idx].aprDisclaimer;
                 return (

--- a/tests/functional/v2/config/CA/DEV_CA_LONG_TERM_CHECKOUT.js
+++ b/tests/functional/v2/config/CA/DEV_CA_LONG_TERM_CHECKOUT.js
@@ -10,9 +10,9 @@ export const DEV_CA_LONG_TERM_CHECKOUT = {
             message: 'Qualifying Pay Monthly',
             expectedValue: 'Pay Monthly',
             modalContent: {
-                offerHeadline: '$5.15/mo. for 12 months',
-                updatedOfferHeadline: '$52.50/mo. for 12 months',
-                offerFieldValues: ['26%', '$12.74', '$61.74'],
+                offerHeadline: '$9.23/mo. for 6 months',
+                updatedOfferHeadline: '$94.17/mo. for 6 months',
+                offerFieldValues: ['26%', '$6.37', '$55.37'],
                 aprDisclaimer: '*APR is 0% to 31.99%. Terms and rates vary based on purchase amount and your credit.',
                 cta: 'Continue with Pay Monthly'
             }
@@ -22,9 +22,9 @@ export const DEV_CA_LONG_TERM_CHECKOUT = {
             message: 'Qualifying Pay Monthly',
             expectedValue: 'Pay Monthly',
             modalContent: {
-                offerHeadline: '$105.00/mo. for 12 months',
-                updatedOfferHeadline: '$52.50/mo. for 12 months',
-                offerFieldValues: ['26%', '$260.00', '$1,260.00'],
+                offerHeadline: '$188.33/mo. for 6 months',
+                updatedOfferHeadline: '$94.17/mo. for 6 months',
+                offerFieldValues: ['26%', '$130.00', '$1,130.00'],
                 aprDisclaimer: '*APR is 0% to 31.99%. Terms and rates vary based on purchase amount and your credit.',
                 cta: 'Continue with Pay Monthly'
             }

--- a/tests/functional/v2/config/CA/DEV_CA_LONG_TERM_CHECKOUT_FR.js
+++ b/tests/functional/v2/config/CA/DEV_CA_LONG_TERM_CHECKOUT_FR.js
@@ -10,9 +10,9 @@ export const DEV_CA_LONG_TERM_CHECKOUT_FR = {
             message: 'Qualifying Pay Monthly',
             expectedValue: 'Payer par mois',
             modalContent: {
-                offerHeadline: '$5.15 CAD/mois pendant 12 mois',
-                updatedOfferHeadline: '$52.50 CAD/mois pendant 12 mois',
-                offerFieldValues: ['26%', '$12.74', '$61.74'],
+                offerHeadline: '$9.23 CAD/mois pendant 6 mois',
+                updatedOfferHeadline: '$94.17 CAD/mois pendant 6 mois',
+                offerFieldValues: ['26%', '$6.37', '$55.37'],
                 aprDisclaimer:
                     "*Le TAEG est de 0 % à 31,99 %. Les conditions et les taux varient en fonction du montant de l'achat et de votre crédit.",
                 cta: 'Continuer avec Payer par mois'

--- a/tests/functional/v2/config/ES/DEV_ES_LONG_TERM.js
+++ b/tests/functional/v2/config/ES/DEV_ES_LONG_TERM.js
@@ -21,8 +21,8 @@ export const DEV_ES_LONG_TERM = {
             message: 'Qualifying Pay Monthly',
             expectedValue: 'Paga en 6, 12 o 24 plazos',
             modalContent: {
-                offerHeadline: '2,50 €/mes',
-                updatedOfferHeadline: '20,83 €/mes',
+                offerHeadline: '10,00 €/mes',
+                updatedOfferHeadline: '83,33 €/mes',
                 offerFieldValues: ['60,00 €', '0,00 €', '0,00 €', '60,00 €'],
                 aprDisclaimer: 'Tipo de interes nominal (TIN) fijo anual del 0%'
             }

--- a/tests/functional/v2/config/ES/DEV_ES_LONG_TERM_0APR.js
+++ b/tests/functional/v2/config/ES/DEV_ES_LONG_TERM_0APR.js
@@ -21,8 +21,8 @@ export const DEV_ES_LONG_TERM_0APR = {
             message: 'Qualifying ES Long Term Installments',
             expectedValue: 'Desde 5,00 € al mes al 0% TAE.',
             modalContent: {
-                offerHeadline: '5,00 €/mes*',
-                updatedOfferHeadline: '20,83 €/mes*',
+                offerHeadline: '20,00 €/mes*',
+                updatedOfferHeadline: '83,33 €/mes*',
                 offerFieldValues: ['120,00 €', '0,00 €', '0,00 €', '120,00 €'],
                 aprDisclaimer: 'TIN fijo anual del 0%'
             }

--- a/tests/functional/v2/config/IT/DEV_IT_LONG_TERM.js
+++ b/tests/functional/v2/config/IT/DEV_IT_LONG_TERM.js
@@ -21,8 +21,8 @@ export const DEV_IT_LONG_TERM = {
             message: 'Qualifying Pay Monthly',
             expectedValue: 'Paga in 6, 12 o 24 rate',
             modalContent: {
-                offerHeadline: '2,50 €/mese',
-                updatedOfferHeadline: '20,83 €/mese',
+                offerHeadline: '10,00 €/mese',
+                updatedOfferHeadline: '83,33 €/mese',
                 offerFieldValues: ['60,00 €', '0,00 €', '0,00 €', '60,00 €'],
                 aprDisclaimer: 'Tasso annuo nominale fisso dello 0%'
             }

--- a/tests/functional/v2/config/IT/DEV_IT_LONG_TERM_0APR.js
+++ b/tests/functional/v2/config/IT/DEV_IT_LONG_TERM_0APR.js
@@ -21,8 +21,8 @@ export const DEV_IT_LONG_TERM_0APR = {
             message: 'Qualifying IT Long Term Installments',
             expectedValue: 'A partire da 5,00 € al mese con TAEG 0%.',
             modalContent: {
-                offerHeadline: '5,00 €/mese*',
-                updatedOfferHeadline: '20,83 €/mese*',
+                offerHeadline: '20,00 €/mese*',
+                updatedOfferHeadline: '83,33 €/mese*',
                 offerFieldValues: ['120,00 €', '0,00 €', '0,00 €', '120,00 €'],
                 aprDisclaimer: 'Tasso annuo nominale fisso dello 0%'
             }


### PR DESCRIPTION
## Description

Removed the ES,IT,CA offer-array reversal logic that forced ascending (6→12→24 month) display order for long-term offers.

## Screenshots / Videos

N/A

## Testing instructions

N/A

## Review

<!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->

The expected SLA for reviews in this repo is days.

