### PR TITLE
chore: align contribution guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
     PR guidelines:
     - Delete this comment so the preview begins with your description
     - Make sure not to include any internal links
+    - Scan the title, body, branch, commits, screenshots, and test instructions for internal URLs, stage tags, identifiers, service details, credentials, and merchant or customer data
     - Please fill out all sections where applicable!
     - PR title should be in the format <prefix>: <short description>
         - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
@@ -16,16 +17,19 @@
 
 ## Screenshots / Videos
 
-<!-- Add any relevant screenshots, GIFs, or a short video demo. For non-UI changes, write "N/A". -->
+<!-- Add before/after screenshots, GIFs, or a short video for visible UI changes. For semantics-only or non-UI changes, write "N/A" and include exact DOM, accessibility-tree, or automated evidence under Testing instructions. -->
 
 ## Testing instructions
 
 <!--
     Include any useful information that will help with testing this change specifically, if applicable
     General testing setup can be omitted - this should focus on setup unique to this PR
+    For bug fixes, name the regression covered and the exact command that passes with the fix
 -->
 
 ## Review
+
+<!-- For fork PRs, note any maintainer actions still needed, such as applying review labels or approving GitHub Actions workflows. -->
 
 <!-- SLA: Please give us 3 days to engage with your PR. We will be notified when it is created. -->
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: lts/*
+                  node-version-file: '.nvmrc'
             - name: Install dependencies
               run: npm i
             - name: Install Playwright Browsers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 
 ## Project snapshot
 
--   **Runtime**: Node `20` (see `.nvmrc`)
+-   **Runtime**: use the Node version in `.nvmrc` (currently `22`); treat `.nvmrc` as the source of truth
 -   **Build**: Webpack 4 + `@krakenjs/webpack-config-grumbler` (`webpack.config.js`, `webpack.config.dev.js`)
 -   **UI**: Preact + JSX (`preact`, `@krakenjs/jsx-pragmatic`) + SCSS (modal v2)
 -   **Cross-domain components**: Zoid + Post-Robot (`@krakenjs/zoid`, `@krakenjs/post-robot`)
@@ -199,6 +199,14 @@ Use Playwright’s interactive modes when tests fail or when implementing a comp
 -   Include a clear plan with acceptance criteria before implementing non-trivial changes.
 -   Keep changes aligned with repo patterns (webpack targets, demo verification, test suites).
 -   Run the most relevant local gates for the impacted area(s) and cite the commands you executed.
+
+## Pull request evidence
+
+-   Before publishing a public PR, scan its title, body, branch, commits, screenshots, and testing instructions for internal URLs, stage tags, identifiers, service details, credentials, and merchant or customer data. Replace them with public local-demo instructions.
+-   Include screenshots or video for visible UI changes. For semantics-only changes, write `N/A` and include the exact DOM, accessibility-tree, or automated assertion that proves the behavior.
+-   Bug-fix testing instructions must name the regression covered and the exact command that passes with the fix.
+-   After opening the PR, verify the live title, body, base branch, diff, labels, and checks.
+-   For fork PRs, report missing review labels and `action_required` workflows as maintainer actions. Do not describe missing or unapproved checks as passing.
 
 ## Plan Mode Default
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,12 @@ $ git pull upstream
 # Install dependencies
 $ npm install
 
-# Run scripts to verify installation (Note: test includes lint)
+# Run scripts to verify installation
+$ npm run lint
 $ npm test
 ```
+
+Fork-based pull requests may require a maintainer to apply review labels and approve GitHub Actions workflows. Call those out in the pull request's Review section rather than treating missing checks as passing.
 
 ## Making Changes
 


### PR DESCRIPTION
## Description

This aligns the contribution path with the repository's actual contracts:

- `.nvmrc` is the Node source of truth, including Playwright CI
- lint and unit tests are documented as separate gates
- visible UI changes require before/after evidence
- semantics-only changes require exact accessibility evidence
- public PR metadata and evidence get a safety scan before publishing
- live PR title, body, base, diff, labels, and checks get verified after publishing
- fork-only maintainer actions stay explicit; missing labels or unapproved workflows are never reported as passing

## Screenshots / Videos

N/A — contributor guidance and CI configuration only.

## Testing instructions

- `prettier --check .github/PULL_REQUEST_TEMPLATE.md .github/workflows/playwright.yml AGENTS.md CONTRIBUTING.md`
- `git diff --check`

## Review

Please start with the PR evidence rules and the Playwright Node version.
