### PR TITLE
fix: make modal loading states accessible

### DIFF
--- a/content/modals/AT/long_term.json
+++ b/content/modals/AT/long_term.json
@@ -28,7 +28,8 @@
             "inputLabel": "Warenwert",
             "inputPlaceholder": "{formattedMinAmount} - {formattedMaxAmount}",
             "inputCurrencySymbol": "€",
-            "genericError": "Etwas ist schief gelaufen. Versuchen Sie es später erneut."
+            "genericError": "Etwas ist schief gelaufen. Versuchen Sie es später erneut.",
+            "loadingLabel": "Finanzierungsoptionen werden geladen"
         },
         "instructions": [
             "Wählen Sie PayPal als Bezahlmethode aus, um mit<strong> PayPal Ratenzahlung</strong> zu bezahlen.",

--- a/content/modals/CA/long_term_xo.json
+++ b/content/modals/CA/long_term_xo.json
@@ -25,7 +25,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "$0",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/CA/long_term_xo_fr.json
+++ b/content/modals/CA/long_term_xo_fr.json
@@ -26,7 +26,8 @@
             "title": "Quel est le montant de votre achat?",
             "inputLabel": "Montant de l'achat",
             "inputPlaceholder": "0 CAD",
-            "genericError": "Une erreur s’est produite. Veuillez réessayer plus tard."
+            "genericError": "Une erreur s’est produite. Veuillez réessayer plus tard.",
+            "loadingLabel": "Chargement des options de financement"
         },
         "genericDisclaimer": "Les conditions varient en fonction du montant de l'achat et de votre crédit.",
         "instructions": [

--- a/content/modals/DE/long_term.json
+++ b/content/modals/DE/long_term.json
@@ -28,7 +28,8 @@
             "inputLabel": "Warenwert",
             "inputPlaceholder": "{formattedMinAmount} - {formattedMaxAmount}",
             "inputCurrencySymbol": "€",
-            "genericError": "Etwas ist schief gelaufen. Versuchen Sie es später erneut."
+            "genericError": "Etwas ist schief gelaufen. Versuchen Sie es später erneut.",
+            "loadingLabel": "Finanzierungsoptionen werden geladen"
         },
         "instructions": [
             "Wählen Sie PayPal als Bezahlmethode aus, um mit<strong> PayPal Ratenzahlung</strong> zu bezahlen.",

--- a/content/modals/DE/long_term_en.json
+++ b/content/modals/DE/long_term_en.json
@@ -29,7 +29,8 @@
             "inputLabel": "Value of goods",
             "inputPlaceholder": "{formattedMinAmount} - {formattedMaxAmount}",
             "inputCurrencySymbol": "€",
-            "genericError": "Something went wrong. Please try later."
+            "genericError": "Something went wrong. Please try later.",
+            "loadingLabel": "Loading financing options"
         },
         "instructions": [
             "Choose PayPal at checkout to pay later with<strong> PayPal Ratenzahlung</strong>.",

--- a/content/modals/ES/long_term.json
+++ b/content/modals/ES/long_term.json
@@ -29,7 +29,8 @@
             "inputLabel": "Importe de compra",
             "inputPlaceholder": "0 €",
             "inputCurrencySymbol": "€",
-            "genericError": "Algo salió mal. Por favor, inténtalo de nuevo más tarde."
+            "genericError": "Algo salió mal. Por favor, inténtalo de nuevo más tarde.",
+            "loadingLabel": "Cargando opciones de financiación"
         },
         "genericDisclaimer": "*Todos los ejemplos tienen carácter representativo. Las condiciones finales y los tipos de interés varían en función del importe de la compra y el perfil del cliente. El importe de los plazos está redondeado.",
         "instructions": [

--- a/content/modals/ES/long_term_en.json
+++ b/content/modals/ES/long_term_en.json
@@ -30,7 +30,8 @@
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "0 €",
             "inputCurrencySymbol": "€",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "All examples are representative. Terms and rates vary based on purchase amount and the customer profile.",
         "instructions": [

--- a/content/modals/IT/long_term.json
+++ b/content/modals/IT/long_term.json
@@ -29,7 +29,8 @@
             "inputLabel": "Importo dell'acquisto",
             "inputPlaceholder": "0 €",
             "inputCurrencySymbol": "€",
-            "genericError": "Qualcosa è andato storto. Riprova più tardi."
+            "genericError": "Qualcosa è andato storto. Riprova più tardi.",
+            "loadingLabel": "Caricamento delle opzioni di finanziamento"
         },
         "genericDisclaimer": "*Tutti gli esempi hanno natura rappresentativa. Le condizioni finali e i tassi d'interesse applicati variano in base all'importo dell'acquisto e al profilo del cliente. L’importo delle rate è arrotondato.",
         "instructions": [

--- a/content/modals/IT/long_term_en.json
+++ b/content/modals/IT/long_term_en.json
@@ -30,7 +30,8 @@
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "0 €",
             "inputCurrencySymbol": "€",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "All examples are representative. Terms and rates vary based on purchase amount and the customer profile.",
         "instructions": [

--- a/content/modals/US/PL2GO/apple_wallet_long_term.json
+++ b/content/modals/US/PL2GO/apple_wallet_long_term.json
@@ -27,7 +27,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/PL2GO/pl2go_long_term.json
+++ b/content/modals/US/PL2GO/pl2go_long_term.json
@@ -27,7 +27,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/PLHub/plhub_long_term.json
+++ b/content/modals/US/PLHub/plhub_long_term.json
@@ -26,7 +26,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/long_term_df.json
+++ b/content/modals/US/long_term_df.json
@@ -27,7 +27,8 @@
             "genericTitle": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": {

--- a/content/modals/US/v2_long_term-onboarding.json
+++ b/content/modals/US/v2_long_term-onboarding.json
@@ -26,7 +26,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/v2_long_term.json
+++ b/content/modals/US/v2_long_term.json
@@ -27,7 +27,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/v2_long_term_rb.json
+++ b/content/modals/US/v2_long_term_rb.json
@@ -27,7 +27,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": [

--- a/content/modals/US/v2_long_term_xo.json
+++ b/content/modals/US/v2_long_term_xo.json
@@ -26,7 +26,8 @@
             "title": "How much is your purchase?",
             "inputLabel": "Purchase amount",
             "inputPlaceholder": "Enter amount",
-            "genericError": "Something went wrong. Please try again later."
+            "genericError": "Something went wrong. Please try again later.",
+            "loadingLabel": "Loading financing options"
         },
         "genericDisclaimer": "Terms vary based on purchase amount and your credit.",
         "instructions": {

--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -254,7 +254,7 @@ const Calculator = ({
                 {isLoading ? loadingLabel : ''}
             </div>
             {(hasInitialAmount || hasUsedInputField) && !error ? (
-                <div className="content-column" aria-busy={isLoading ? 'true' : undefined}>
+                <div className="content-column" aria-live="polite" aria-busy={isLoading ? 'true' : undefined}>
                     <TermsTable
                         view={view}
                         isLoading={isLoading}

--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -84,7 +84,7 @@ const Calculator = ({
     const { amount } = useXProps();
     const { country, views } = useServerData();
     const { language } = views[0].meta;
-    const { title, genericTitle, inputLabel, inputPlaceholder, inputCurrencySymbol } = calculator;
+    const { title, genericTitle, inputLabel, inputPlaceholder, inputCurrencySymbol, loadingLabel } = calculator;
     const formattedInputPlaceholder = currencyFormat(inputPlaceholder).replace(/(\s?€)/g, '');
 
     // Set hasUsedInputField to true if someone has typed in the input field at any point.
@@ -243,8 +243,11 @@ const Calculator = ({
                 </div>
                 <div aria-live="polite">{renderError(error || emptyState || isLoading)}</div>
             </form>
+            <div role="status" className="sr-only">
+                {isLoading ? loadingLabel : ''}
+            </div>
             {(hasInitialAmount || hasUsedInputField) && !error ? (
-                <div aria-live="polite" className="content-column">
+                <div className="content-column" aria-busy={isLoading ? 'true' : undefined}>
                     <TermsTable
                         view={view}
                         isLoading={isLoading}

--- a/src/components/modal/v2/parts/Calculator.jsx
+++ b/src/components/modal/v2/parts/Calculator.jsx
@@ -84,7 +84,14 @@ const Calculator = ({
     const { amount } = useXProps();
     const { country, views } = useServerData();
     const { language } = views[0].meta;
-    const { title, genericTitle, inputLabel, inputPlaceholder, inputCurrencySymbol, loadingLabel } = calculator;
+    const {
+        title,
+        genericTitle,
+        inputLabel,
+        inputPlaceholder,
+        inputCurrencySymbol,
+        loadingLabel = 'Loading financing options'
+    } = calculator;
     const formattedInputPlaceholder = currencyFormat(inputPlaceholder).replace(/(\s?€)/g, '');
 
     // Set hasUsedInputField to true if someone has typed in the input field at any point.

--- a/src/components/modal/v2/parts/LoadingShimmer.jsx
+++ b/src/components/modal/v2/parts/LoadingShimmer.jsx
@@ -16,7 +16,7 @@ const LoadingShimmer = ({ numOffers = 3, offerCountry, useNewCheckoutDesign }) =
             {Array.from({ length: numOffers }).map((_, index) => {
                 if (accordionShimmerCountries.includes(offerCountry)) {
                     return (
-                        <div id={index} className="accordion__container shimmer">
+                        <div id={index} className="accordion__container shimmer" aria-hidden="true">
                             <div className="accordion__row">
                                 <div className="accordion__header-container loading">
                                     <div className="offer__field-loading" style={{ width: '60%' }} />
@@ -31,6 +31,7 @@ const LoadingShimmer = ({ numOffers = 3, offerCountry, useNewCheckoutDesign }) =
                         className={`offer__container shimmer key=${index} ${
                             useNewCheckoutDesign === 'true' ? 'checkout' : ''
                         }`}
+                        aria-hidden="true"
                     >
                         <div className="offer__row">
                             <div className="offer__field-loading" />

--- a/src/components/modal/v2/styles/components/_loading-shimmer.scss
+++ b/src/components/modal/v2/styles/components/_loading-shimmer.scss
@@ -45,7 +45,7 @@
         height: 20px;
         margin: 4px 0;
         animation: shimmer 2s linear infinite;
-        background: linear-gradient(to bottom right, #f1efea 21%, #e4e0d6 25%, #f1efea 29%);
+        background: linear-gradient(to bottom right, #949494 21%, #767676 25%, #949494 29%);
         background-size: 3000px 1000px;
         width: 100%;
     }
@@ -95,7 +95,7 @@
         height: 20px;
         margin: 4px 0;
         animation: shimmer 2s linear infinite;
-        background: linear-gradient(to bottom right, #cdd0d4 21%, #e9e9e9 25%, #cdd0d4 29%);
+        background: linear-gradient(to bottom right, #949494 21%, #767676 25%, #949494 29%);
         background-size: 3000px 1000px;
         width: 85%;
     }

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -26,6 +26,67 @@ const contrastRatio = (firstColor, secondColor) => {
     return (luminances[0] + 0.05) / (luminances[1] + 0.05);
 };
 
+/**
+ * Measures each rendered shimmer color against the ancestor backgrounds behind it.
+ * @param {import('@playwright/test').Locator} shimmers Rendered shimmer elements.
+ * @returns {Promise<Array<{ foregroundColor: Array<Number>, backgroundColor: Array<Number> }>>} Color pairs.
+ */
+const getShimmerContrastMeasurements = shimmers =>
+    shimmers.evaluateAll(elements => {
+        const parseCssColor = value => {
+            const channels = value.match(/[\d.]+/g)?.map(Number);
+
+            if (!channels || channels.length < 3) {
+                throw new Error(`Unsupported CSS color: ${value}`);
+            }
+
+            return [...channels.slice(0, 3), channels[3] ?? 1];
+        };
+
+        const compositeColor = ([foregroundRed, foregroundGreen, foregroundBlue, foregroundAlpha], background) => {
+            const [backgroundRed, backgroundGreen, backgroundBlue, backgroundAlpha] = background;
+            const alpha = foregroundAlpha + backgroundAlpha * (1 - foregroundAlpha);
+
+            if (alpha === 0) {
+                return [0, 0, 0, 0];
+            }
+
+            return [
+                (foregroundRed * foregroundAlpha + backgroundRed * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
+                (foregroundGreen * foregroundAlpha +
+                    backgroundGreen * backgroundAlpha * (1 - foregroundAlpha)) /
+                    alpha,
+                (foregroundBlue * foregroundAlpha +
+                    backgroundBlue * backgroundAlpha * (1 - foregroundAlpha)) /
+                    alpha,
+                alpha
+            ];
+        };
+
+        const getEffectiveBackgroundColor = element => {
+            const ancestorColors = [];
+
+            for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
+                ancestorColors.push(parseCssColor(window.getComputedStyle(ancestor).backgroundColor));
+            }
+
+            return ancestorColors
+                .reverse()
+                .reduce((background, foreground) => compositeColor(foreground, background), [255, 255, 255, 1])
+                .slice(0, 3);
+        };
+
+        return elements.flatMap(element => {
+            const backgroundImage = window.getComputedStyle(element).backgroundImage;
+            const foregroundColors = Array.from(backgroundImage.matchAll(/rgba?\([^)]+\)/g), match =>
+                parseCssColor(match[0]).slice(0, 3)
+            );
+            const backgroundColor = getEffectiveBackgroundColor(element);
+
+            return foregroundColors.map(foregroundColor => ({ foregroundColor, backgroundColor }));
+        });
+    });
+
 modalTest.describe('Long Term Modals', () => {
     ['DEV_US_LONG_TERM', 'DEV_US_LONG_TERM_CHECKOUT'].forEach(account => {
         modalTest(`Announces ${account} loading with contrasting shimmers`, async ({ navigatePage, loadModal }) => {
@@ -41,15 +102,12 @@ modalTest.describe('Long Term Modals', () => {
 
             const shimmers = modalIframe.locator('.offer__field-loading');
             expect(await shimmers.count()).toBeGreaterThan(0);
-            const gradients = await shimmers.evaluateAll(elements =>
-                elements.map(element => window.getComputedStyle(element).backgroundImage)
-            );
-            const shimmerColors = gradients.flatMap(gradient =>
-                Array.from(gradient.matchAll(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/g), match => match.slice(1).map(Number))
-            );
+            const contrastMeasurements = await getShimmerContrastMeasurements(shimmers);
 
-            expect(shimmerColors.length).toBeGreaterThan(0);
-            shimmerColors.forEach(color => expect(contrastRatio(color, [255, 255, 255])).toBeGreaterThanOrEqual(3));
+            expect(contrastMeasurements).not.toHaveLength(0);
+            contrastMeasurements.forEach(({ foregroundColor, backgroundColor }) =>
+                expect(contrastRatio(foregroundColor, backgroundColor)).toBeGreaterThanOrEqual(3)
+            );
         });
     });
 

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -128,7 +128,7 @@ modalTest.describe('Long Term Modals', () => {
             const loadingStatus = modalIframe.getByRole('status');
             await expect(loadingStatus).toHaveCount(1);
             await expect(loadingStatus).toHaveText(loadingLabel);
-            await expect(modalIframe.locator('.content-column[aria-busy="true"]')).toHaveCount(1);
+            await expect(modalIframe.locator('.content-column[aria-live="polite"][aria-busy="true"]')).toHaveCount(1);
 
             const shimmerContainers = modalIframe.locator(shimmerContainer);
             await expect(shimmerContainers).not.toHaveCount(0);

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -53,12 +53,9 @@ const getShimmerContrastMeasurements = shimmers =>
 
             return [
                 (foregroundRed * foregroundAlpha + backgroundRed * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
-                (foregroundGreen * foregroundAlpha +
-                    backgroundGreen * backgroundAlpha * (1 - foregroundAlpha)) /
+                (foregroundGreen * foregroundAlpha + backgroundGreen * backgroundAlpha * (1 - foregroundAlpha)) /
                     alpha,
-                (foregroundBlue * foregroundAlpha +
-                    backgroundBlue * backgroundAlpha * (1 - foregroundAlpha)) /
-                    alpha,
+                (foregroundBlue * foregroundAlpha + backgroundBlue * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
                 alpha
             ];
         };
@@ -76,7 +73,7 @@ const getShimmerContrastMeasurements = shimmers =>
         };
 
         return elements.flatMap(element => {
-            const backgroundImage = window.getComputedStyle(element).backgroundImage;
+            const { backgroundImage } = window.getComputedStyle(element);
             const foregroundColors = Array.from(backgroundImage.matchAll(/rgba?\([^)]+\)/g), match =>
                 parseCssColor(match[0])
             );

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -27,7 +27,7 @@ const contrastRatio = (firstColor, secondColor) => {
 };
 
 /**
- * Measures each rendered shimmer color against the ancestor backgrounds behind it.
+ * Measures each rendered shimmer color against the composited background layers behind it.
  * @param {import('@playwright/test').Locator} shimmers Rendered shimmer elements.
  * @returns {Promise<Array<{ foregroundColor: Array<Number>, backgroundColor: Array<Number> }>>} Color pairs.
  */
@@ -64,26 +64,28 @@ const getShimmerContrastMeasurements = shimmers =>
         };
 
         const getEffectiveBackgroundColor = element => {
-            const ancestorColors = [];
+            const backgroundLayers = [];
 
-            for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
-                ancestorColors.push(parseCssColor(window.getComputedStyle(ancestor).backgroundColor));
+            for (let layer = element; layer; layer = layer.parentElement) {
+                backgroundLayers.push(parseCssColor(window.getComputedStyle(layer).backgroundColor));
             }
 
-            return ancestorColors
+            return backgroundLayers
                 .reverse()
-                .reduce((background, foreground) => compositeColor(foreground, background), [255, 255, 255, 1])
-                .slice(0, 3);
+                .reduce((background, foreground) => compositeColor(foreground, background), [255, 255, 255, 1]);
         };
 
         return elements.flatMap(element => {
             const backgroundImage = window.getComputedStyle(element).backgroundImage;
             const foregroundColors = Array.from(backgroundImage.matchAll(/rgba?\([^)]+\)/g), match =>
-                parseCssColor(match[0]).slice(0, 3)
+                parseCssColor(match[0])
             );
             const backgroundColor = getEffectiveBackgroundColor(element);
 
-            return foregroundColors.map(foregroundColor => ({ foregroundColor, backgroundColor }));
+            return foregroundColors.map(foregroundColor => ({
+                foregroundColor: compositeColor(foregroundColor, backgroundColor).slice(0, 3),
+                backgroundColor: backgroundColor.slice(0, 3)
+            }));
         });
     });
 

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -87,9 +87,41 @@ const getShimmerContrastMeasurements = shimmers =>
         });
     });
 
+const loadingContrastScenarios = [
+    {
+        name: 'standard card',
+        account: 'DEV_US_LONG_TERM',
+        loadingLabel: 'Loading financing options',
+        shimmerContainer: '.offer__container.shimmer'
+    },
+    {
+        name: 'checkout card',
+        account: 'DEV_US_LONG_TERM_CHECKOUT',
+        loadingLabel: 'Loading financing options',
+        shimmerContainer: '.offer__container.shimmer'
+    },
+    {
+        name: 'accordion',
+        account: 'DEV_DE_LONG_TERM',
+        loadingLabel: 'Finanzierungsoptionen werden geladen',
+        shimmerContainer: '.accordion__container.shimmer'
+    },
+    {
+        name: 'dark-mode card',
+        account: 'DEV_US_LONG_TERM_PL2GO',
+        colorScheme: 'dark',
+        loadingLabel: 'Loading financing options',
+        shimmerContainer: '.content__row.dynamic.darkMode .offer__container.shimmer'
+    }
+];
+
 modalTest.describe('Long Term Modals', () => {
-    ['DEV_US_LONG_TERM', 'DEV_US_LONG_TERM_CHECKOUT'].forEach(account => {
-        modalTest(`Announces ${account} loading with contrasting shimmers`, async ({ navigatePage, loadModal }) => {
+    loadingContrastScenarios.forEach(({ name, account, colorScheme, loadingLabel, shimmerContainer }) => {
+        modalTest(`Announces ${name} loading with contrasting shimmers`, async ({ navigatePage, page, loadModal }) => {
+            if (colorScheme) {
+                await page.emulateMedia({ colorScheme });
+            }
+
             await navigatePage({ account, amount: '', offer: 'PAY_LATER_LONG_TERM' });
             const modalIframeElement = await loadModal();
             const modalIframe = await modalIframeElement.contentFrame();
@@ -97,10 +129,12 @@ modalTest.describe('Long Term Modals', () => {
             await modalIframe.locator('input').fill('100');
             const loadingStatus = modalIframe.getByRole('status');
             await expect(loadingStatus).toHaveCount(1);
-            await expect(loadingStatus).toHaveText('Loading financing options');
+            await expect(loadingStatus).toHaveText(loadingLabel);
             await expect(modalIframe.locator('.content-column[aria-busy="true"]')).toHaveCount(1);
 
-            const shimmers = modalIframe.locator('.offer__field-loading');
+            const shimmerContainers = modalIframe.locator(shimmerContainer);
+            await expect(shimmerContainers).not.toHaveCount(0);
+            const shimmers = shimmerContainers.locator('.offer__field-loading');
             expect(await shimmers.count()).toBeGreaterThan(0);
             const contrastMeasurements = await getShimmerContrastMeasurements(shimmers);
 

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -53,8 +53,7 @@ const getShimmerContrastMeasurements = shimmers =>
 
             return [
                 (foregroundRed * foregroundAlpha + backgroundRed * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
-                (foregroundGreen * foregroundAlpha + backgroundGreen * backgroundAlpha * (1 - foregroundAlpha)) /
-                    alpha,
+                (foregroundGreen * foregroundAlpha + backgroundGreen * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
                 (foregroundBlue * foregroundAlpha + backgroundBlue * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
                 alpha
             ];

--- a/tests/playwright/tests/sdk/modals/multi.spec.js
+++ b/tests/playwright/tests/sdk/modals/multi.spec.js
@@ -1,7 +1,58 @@
 import { expect } from '@playwright/test';
 import { modalTest } from '../../../pages/modals_fixture';
 
+/**
+ * Calculates relative luminance for an RGB color.
+ * @param {Array<Number>} color Red, green, and blue channels.
+ * @returns {Number} Relative luminance from 0 to 1.
+ */
+const relativeLuminance = color => {
+    const channels = color
+        .map(channel => channel / 255)
+        .map(channel => (channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4));
+
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+};
+
+/**
+ * Calculates the WCAG contrast ratio between two RGB colors.
+ * @param {Array<Number>} firstColor First RGB color.
+ * @param {Array<Number>} secondColor Second RGB color.
+ * @returns {Number} Contrast ratio from 1 to 21.
+ */
+const contrastRatio = (firstColor, secondColor) => {
+    const luminances = [relativeLuminance(firstColor), relativeLuminance(secondColor)].sort((a, b) => b - a);
+
+    return (luminances[0] + 0.05) / (luminances[1] + 0.05);
+};
+
 modalTest.describe('Long Term Modals', () => {
+    ['DEV_US_LONG_TERM', 'DEV_US_LONG_TERM_CHECKOUT'].forEach(account => {
+        modalTest(`Announces ${account} loading with contrasting shimmers`, async ({ navigatePage, loadModal }) => {
+            await navigatePage({ account, amount: '', offer: 'PAY_LATER_LONG_TERM' });
+            const modalIframeElement = await loadModal();
+            const modalIframe = await modalIframeElement.contentFrame();
+
+            await modalIframe.locator('input').fill('100');
+            const loadingStatus = modalIframe.getByRole('status');
+            await expect(loadingStatus).toHaveCount(1);
+            await expect(loadingStatus).toHaveText('Loading financing options');
+            await expect(modalIframe.locator('.content-column[aria-busy="true"]')).toHaveCount(1);
+
+            const shimmers = modalIframe.locator('.offer__field-loading');
+            expect(await shimmers.count()).toBeGreaterThan(0);
+            const gradients = await shimmers.evaluateAll(elements =>
+                elements.map(element => window.getComputedStyle(element).backgroundImage)
+            );
+            const shimmerColors = gradients.flatMap(gradient =>
+                Array.from(gradient.matchAll(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/g), match => match.slice(1).map(Number))
+            );
+
+            expect(shimmerColors.length).toBeGreaterThan(0);
+            shimmerColors.forEach(color => expect(contrastRatio(color, [255, 255, 255])).toBeGreaterThanOrEqual(3));
+        });
+    });
+
     modalTest('US Long Term Multi & LT Q', async ({ navigatePage, loadModal, modalAxeCoreScan }) => {
         await navigatePage({ account: 'DEV_US_MULTI', amount: 1501, offer: 'PAY_LATER_LONG_TERM' });
         const modalIframeElement = await loadModal();

--- a/tests/unit/spec/content/modalAccessibility.test.js
+++ b/tests/unit/spec/content/modalAccessibility.test.js
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Returns every JSON file below a directory.
+ * @param {String} directory Directory to scan.
+ * @returns {Array<String>} Absolute JSON file paths.
+ */
+const findJsonFiles = directory =>
+    fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return findJsonFiles(entryPath);
+        }
+
+        return entry.isFile() && entry.name.endsWith('.json') ? [entryPath] : [];
+    });
+
+describe('modal accessibility content', () => {
+    const modalContentRoot = path.resolve('content/modals');
+    const calculatorContent = findJsonFiles(modalContentRoot)
+        .map(filePath => ({ filePath, content: JSON.parse(fs.readFileSync(filePath, 'utf8')) }))
+        .filter(({ content }) => content.content?.calculator);
+
+    test('discovers calculator content', () => {
+        expect(calculatorContent).not.toHaveLength(0);
+    });
+
+    test.each(calculatorContent)('$filePath provides a loading announcement', ({ content }) => {
+        expect(content.content.calculator.loadingLabel).toEqual(expect.any(String));
+        expect(content.content.calculator.loadingLabel.trim()).not.toHaveLength(0);
+    });
+});

--- a/tests/unit/spec/src/components/modal/v2/parts/Calculator.test.js
+++ b/tests/unit/spec/src/components/modal/v2/parts/Calculator.test.js
@@ -43,11 +43,11 @@ const defaultCalculatorState = {
     changeInput: jest.fn()
 };
 
-const renderCalculator = () =>
+const renderCalculator = (calculatorOverrides = {}) =>
     render(
         <Calculator
             setExpandedState={jest.fn()}
-            calculator={calculator}
+            calculator={{ ...calculator, ...calculatorOverrides }}
             aprDisclaimer={{ default: { aprDisclaimer: 'Terms apply.' } }}
         />
     );
@@ -146,5 +146,25 @@ describe('Calculator amount field accessibility', () => {
         expect(input).not.toHaveAttribute('aria-describedby');
         expect(error).not.toHaveAttribute('id');
         expect(error.closest('[aria-live="polite"]')).toBeInTheDocument();
+    });
+});
+
+describe('Calculator loading announcement', () => {
+    beforeEach(() => {
+        mockUseCalculator.mockReturnValue({
+            ...defaultCalculatorState,
+            value: '100',
+            isLoading: true
+        });
+        mockUseXProps.mockReturnValue({ amount: 100 });
+    });
+
+    test.each([
+        ['the English fallback', undefined, 'Loading financing options'],
+        ['localized content', 'Finanzierungsoptionen werden geladen', 'Finanzierungsoptionen werden geladen']
+    ])('uses %s', (_, loadingLabel, expectedLabel) => {
+        renderCalculator({ loadingLabel });
+
+        expect(screen.getByRole('status')).toHaveTextContent(expectedLabel);
     });
 });

--- a/tests/unit/spec/src/components/modal/v2/parts/Calculator.test.js
+++ b/tests/unit/spec/src/components/modal/v2/parts/Calculator.test.js
@@ -163,8 +163,9 @@ describe('Calculator loading announcement', () => {
         ['the English fallback', undefined, 'Loading financing options'],
         ['localized content', 'Finanzierungsoptionen werden geladen', 'Finanzierungsoptionen werden geladen']
     ])('uses %s', (_, loadingLabel, expectedLabel) => {
-        renderCalculator({ loadingLabel });
+        const { container } = renderCalculator({ loadingLabel });
 
         expect(screen.getByRole('status')).toHaveTextContent(expectedLabel);
+        expect(container.querySelector('.content-column[aria-live="polite"]')).toHaveAttribute('aria-busy', 'true');
     });
 });

--- a/tests/unit/spec/src/components/modal/v2/parts/LoadingShimmer.test.js
+++ b/tests/unit/spec/src/components/modal/v2/parts/LoadingShimmer.test.js
@@ -1,0 +1,20 @@
+/** @jsx h */
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+
+import LoadingShimmer from 'src/components/modal/v2/parts/LoadingShimmer';
+
+describe('LoadingShimmer', () => {
+    test.each([
+        ['card', 'US'],
+        ['accordion', 'DE']
+    ])('hides the visual-only %s placeholders from assistive technology', (_, offerCountry) => {
+        const { container } = render(<LoadingShimmer offerCountry={offerCountry} />);
+
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+        const visualPlaceholders = Array.from(container.querySelectorAll('.offer__field-loading'));
+        expect(visualPlaceholders).not.toHaveLength(0);
+        expect(visualPlaceholders.every(placeholder => placeholder.closest('[aria-hidden="true"]'))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Description

This makes the calculator loading state accessible across every current variant. It adds one stable status announcement, keeps completed financing results in a polite live region while updates are busy, hides visual-only placeholders from assistive technology, and raises the shimmer colors to at least 3:1 contrast. The component falls back to "Loading financing options" if content omits a label, while localized content can override it. A content contract still requires every current calculator locale and variant to provide its own loading announcement.

## Screenshots / Videos

Focused captures of the shimmer colors. The modal's separate spinner and blur are intentionally omitted so the contrast change is visible.

### Standard

| Before | After |
| --- | --- |
| ![Standard loading state before the contrast change](https://raw.githubusercontent.com/ryanmagoon/paypal-messaging-components/4a6273215799518f49bafaccec87d439826c7705/pr-evidence/1394/standard-before.png) | ![Standard loading state after the contrast change](https://raw.githubusercontent.com/ryanmagoon/paypal-messaging-components/4a6273215799518f49bafaccec87d439826c7705/pr-evidence/1394/standard-after.png) |

### Checkout

| Before | After |
| --- | --- |
| ![Checkout loading state before the contrast change](https://raw.githubusercontent.com/ryanmagoon/paypal-messaging-components/4a6273215799518f49bafaccec87d439826c7705/pr-evidence/1394/checkout-before.png) | ![Checkout loading state after the contrast change](https://raw.githubusercontent.com/ryanmagoon/paypal-messaging-components/4a6273215799518f49bafaccec87d439826c7705/pr-evidence/1394/checkout-after.png) |

## Testing instructions

Regression coverage verifies the English fallback and localized override, one status region, the combined live and busy results state, card and accordion placeholders, every current calculator content file, and each rendered shimmer color against its composited background. Browser coverage samples standard, checkout, German accordion, and dark-mode layouts.

- `npm run lint`
- `npm test -- --runInBand`
- `npx playwright test tests/playwright/tests/sdk/modals/multi.spec.js`
- `npm run build:production`

## Review

Please start with the loading-state boundary in `Calculator.jsx`, the shared content contract, and the rendered contrast measurements.
