### PR TITLE
feat: render CCDII credit warning in FR Pay Monthly modal (DTCRCMERC-…

### DIFF
--- a/src/components/modal/v2/parts/views/LongTerm/Content.jsx
+++ b/src/components/modal/v2/parts/views/LongTerm/Content.jsx
@@ -81,6 +81,7 @@ export const LongTerm = ({
         genericDisclaimer,
         instructions,
         disclosure,
+        creditWarning,
         navLinkPrefix,
         linkToProductList,
         cta,
@@ -243,6 +244,9 @@ export const LongTerm = ({
                     expandedState={expandedState}
                 />
             </div>
+            {creditWarning && (
+                <div className={`content__row credit-warning ${useDarkMode ? 'darkMode' : ''}`}>{creditWarning}</div>
+            )}
             <div
                 className={`content__row disclosure ${expandedState ? '' : 'collapsed'} ${
                     useNewCheckoutDesign === 'true' ? 'checkout' : ''

--- a/src/components/modal/v2/styles/components/_content.scss
+++ b/src/components/modal/v2/styles/components/_content.scss
@@ -177,6 +177,30 @@
             }
         }
 
+        &.credit-warning {
+            text-align: left;
+            font-size: 18px;
+            font-weight: 400;
+            line-height: 24px;
+            color: colors.$text-main;
+
+            @include mixins.desktop {
+                margin: 20px 30px 0px 30px;
+            }
+
+            @include mixins.tablet {
+                margin: 20px 44px 0px 44px;
+            }
+
+            @include mixins.mobile {
+                margin-top: 10px;
+            }
+
+            &.darkMode {
+                color: colors.$white;
+            }
+        }
+
         &.checkout {
             &.disclosure {
                 @include mixins.desktop {


### PR DESCRIPTION
## Summary
- Render the new CCDII credit warning ("Attention ! Un crédit coûte de l'argent et doit être remboursé.") in the FR Pay Monthly (long-term) modal, sourced from the `creditWarning` content field
- Add shared `.credit-warning` SCSS block in `_content.scss` for styling the warning row

Jira: https://paypal.atlassian.net/browse/DTCRCMERC-5665

Note: the `.credit-warning` SCSS block in `_content.scss` is shared across the FR Pi4x, Pay Monthly, and Product List modal views, so it's duplicated identically across this PR and DTCRCMERC-5664 / DTCRCMERC-5666. Whichever merges first will "own" that hunk; the others should show it as a no-op diff.