### PR TITLE
feat: render CCDII credit warning in FR Product List modal (DTCRCMERC-5666)

### DIFF
--- a/src/components/modal/v2/parts/views/ProductList/Content.jsx
+++ b/src/components/modal/v2/parts/views/ProductList/Content.jsx
@@ -6,7 +6,7 @@ import { currencyFormat } from '../../../lib/hooks/currency';
 import styles from './styles.scss';
 
 export const ProductList = ({
-    content: { instructions, disclosure, productTiles },
+    content: { instructions, disclosure, productTiles, creditWarning },
     useV5Design,
     use5Dot1Design,
     setViewName
@@ -66,6 +66,7 @@ export const ProductList = ({
                     <div className="branded-image" />
                 </div>
             </div>
+            {creditWarning && <div className="content__row credit-warning">{creditWarning}</div>}
             <div
                 className={`content__row disclosure collapsed ${useV5Design ? 'v5Design' : ''} ${getEuroStyleClass(
                     country

--- a/src/components/modal/v2/styles/components/_content.scss
+++ b/src/components/modal/v2/styles/components/_content.scss
@@ -177,6 +177,30 @@
             }
         }
 
+        &.credit-warning {
+            text-align: left;
+            font-size: 18px;
+            font-weight: 400;
+            line-height: 24px;
+            color: colors.$text-main;
+
+            @include mixins.desktop {
+                margin: 20px 30px 0px 30px;
+            }
+
+            @include mixins.tablet {
+                margin: 20px 44px 0px 44px;
+            }
+
+            @include mixins.mobile {
+                margin-top: 10px;
+            }
+
+            &.darkMode {
+                color: colors.$white;
+            }
+        }
+
         &.checkout {
             &.disclosure {
                 @include mixins.desktop {


### PR DESCRIPTION
## Summary
- Render the new CCDII credit warning ("Attention ! Un crédit coûte de l'argent et doit être remboursé.") in the FR Product List modal, sourced from the `creditWarning` content field, positioned after the product tiles
- Add shared `.credit-warning` SCSS block in `_content.scss` for styling the warning row

Jira: https://paypal.atlassian.net/browse/DTCRCMERC-5666

Note: the `.credit-warning` SCSS block in `_content.scss` is shared across the FR Pi4x, Pay Monthly, and Product List modal views, so it's duplicated identically across this PR and DTCRCMERC-5664 / DTCRCMERC-5665. Whichever merges first will "own" that hunk; the others should show it as a no-op diff.