### PR TITLE
fix: default V2 message font size

### DIFF
--- a/src/server/v2/styles.js
+++ b/src/server/v2/styles.js
@@ -17,7 +17,7 @@ const getButtonAlignmentStyles = textAlign => {
     return '';
 };
 
-export default ({ fontFamily, fontSource, fontSize = 14, textAlign = 'left' } = {}) => {
+export default ({ fontFamily, fontSource, fontSize = 12, textAlign = 'left' } = {}) => {
     const { fontFaceRules, effectiveFontFamily } = buildFontRules({
         fontSource,
         fontFamily,

--- a/src/server/v2/validOptions.js
+++ b/src/server/v2/validOptions.js
@@ -8,10 +8,7 @@ export default {
         },
         text: {
             color: [Types.STRING, ['black', 'white', 'monochrome', 'grayscale|greyscale']],
-            // 14 (not 12) matches v5's actual default rendered font-size (see
-            // src/server/message/styles/common.css `html { font-size: 14px }`) — v5 only
-            // overrides this when a merchant explicitly sets style.text.size.
-            size: [Types.NUMBER, [14, 10, 11, 12, 13, 15, 16]],
+            size: [Types.NUMBER, [12, 10, 11, 13, 14, 15, 16]],
             align: [Types.STRING, ['left', 'right', 'center']],
             fontFamily: [Types.ANY],
             fontSource: [Types.ANY]

--- a/tests/unit/spec/server/v2/validateStyle.test.js
+++ b/tests/unit/spec/server/v2/validateStyle.test.js
@@ -1,4 +1,5 @@
 import validateStyle from 'server/v2/validateStyle';
+import buildStyles from 'server/v2/styles';
 
 const mockLog = jest.fn();
 
@@ -65,10 +66,15 @@ describe('v2 validateStyle', () => {
         });
     });
 
-    test('defaults text.size to 14 (matches v5 default rendered font-size) when not provided', () => {
+    test('defaults text.size to 12 when not provided', () => {
         const result = validateStyle(mockLog, { layout: 'text' });
-        expect(result.text.size).toBe(14);
+        expect(result.text.size).toBe(12);
         expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('defaults rendered V2 text to 12px while preserving explicit sizes', () => {
+        expect(buildStyles()).toContain('font-size: 12px;');
+        expect(buildStyles({ fontSize: 14 })).toContain('font-size: 14px;');
     });
 
     test('normalises greyscale alias for text layout text.color', () => {


### PR DESCRIPTION
## Description

Changes the default V2 text font size from 14px to 12px when no size is configured. Keeps explicit supported sizes, including 14px, unchanged.

## Screenshots / Videos

N/A - default style behavior only. Regression assertions verify omitted V2 text size renders 12px and explicit 14px remains 14px.

## Testing instructions

- `npm run lint` - pass
- `npm test -- --runInBand` - pass: 547 tests, 11 snapshots
- `npm test -- --runInBand tests/unit/spec/server/v2/validateStyle.test.js tests/unit/spec/server/v2/render.test.js` - pass: 176 tests, 5 snapshots
- `CONFIG_PATH=US/DEV_US_MULTI npm run test:func:snapshots` - executed; the local runner detached before reporting final status. No snapshot files changed.

## Review

Ready for initial review. Please confirm a V2 message with no configured text size uses the 12px default.