### PR TITLE
rename FI to FUNDING_INSTRUMENT

### DIFF
--- a/src/library/zoid/message/validation.js
+++ b/src/library/zoid/message/validation.js
@@ -200,7 +200,7 @@ export default {
                 'mini-cart',
                 'cart',
                 'checkout',
-                'view-edit-fi'
+                'view-edit-funding-instrument'
             ];
 
             if (!validateType(Types.STRING, pageType)) {

--- a/tests/unit/spec/src/zoid/message/validation.test.js
+++ b/tests/unit/spec/src/zoid/message/validation.test.js
@@ -266,7 +266,7 @@ describe('validate', () => {
             'mini-cart',
             'cart',
             'checkout',
-            'view-edit-fi'
+            'view-edit-funding-instrument'
         ].forEach(supportedPageType => {
             const pageType = validate.pageType({ props: { pageType: supportedPageType } });
 


### PR DESCRIPTION
## Summary
- Renames the `view-edit-fi` pageType value to `view-edit-funding-instrument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)